### PR TITLE
tests: use xfail (xpass) for OpenAI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,4 +75,4 @@ jobs:
 
       - name: Run unit test with tox (disable openai tests for now)
         run: |
-          tox -- -k "not openai"
+          tox

--- a/tests/io/test_granite_3_2.py
+++ b/tests/io/test_granite_3_2.py
@@ -7,6 +7,7 @@
 import json
 
 # Third Party
+from openai import APIConnectionError
 import aconfig
 import pytest
 import torch
@@ -207,6 +208,10 @@ def test_run_transformers(
     # temperature controls, verify outputs
 
 
+@pytest.mark.xfail(
+    reason="APIConnectionError, but OpenAI tests are optional.",
+    raises=APIConnectionError,
+)
 def test_run_openai(
     io_processor_openai: Granite3Point2InputOutputProcessor, input_json_str: str
 ):


### PR DESCRIPTION
Get the filter out of the CI workflow.
Allow CI to xfail since we don't have OpenAI running. Allow devs to run w/ or w/o OpenAI (e.g. ollama).

Probably more skipability coming, but this handles it for now.