### PR TITLE
tests: fix test failing on backend=None

### DIFF
--- a/tests/io/test_granite_3_2.py
+++ b/tests/io/test_granite_3_2.py
@@ -88,8 +88,8 @@ def io_processor_transformers(pytestconfig) -> Granite3Point2InputOutputProcesso
             ),
         )
     except Exception as e:
-        pytest.skip(f"No transformers backend for {model_path}: {e}")
-    return Granite3Point2InputOutputProcessor(backend)
+        pytest.skip(f"No transformers backend for '{model_path}': {e}")
+    return Granite3Point2InputOutputProcessor(backend=backend)
 
 
 @pytest.fixture


### PR DESCRIPTION
Need to set backend=backend because first param
is config.