### PR TITLE
Chain of Thought Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,25 @@ model_name = "granite3.2"
 io_processor = make_io_processor(
     model_name, backend=make_backend("openai", {"model_name": model_name})
 )
+messages=[
+    UserMessage(
+        content="What's the fastest way for a seller to visit all the cities in their region?",
+    )
+]
 
 # Without Thinking
-inputs = ChatCompletionInputs(
-    messages=[
-        UserMessage(
-            content="What's the fastest way for a seller to visit all the cities in their region?",
-        )
-    ],
+outputs = io_processor.create_chat_completion(ChatCompletionInputs(messages=messages))
+print("-- NO THINKING ------")
+print(outputs.next_message.content)
+
+# With Thinking
+outputs = io_processor.create_chat_completion(
+    ChatCompletionInputs(messages=messages, thinking=True)
 )
-outputs = io_processor.create_chat_completion(inputs)
-print(f"ROLE: {outputs.next_message.content}")
-print("--------")
+print("-- WITH THINKING ------")
+print(">> Thoughts:")
+print(outputs.reasoning_content)
+print(">> Response:")
 print(outputs.next_message.content)
 ```
 

--- a/examples/inference.py
+++ b/examples/inference.py
@@ -13,16 +13,8 @@ model_name = "granite3.1"
 io_processor = make_io_processor(
     model_name, backend=make_backend("openai", {"model_name": model_name})
 )
-
-# Without Thinking
-inputs = ChatCompletionInputs(
-    messages=[
-        UserMessage(
-            content="What's the fastest way for a seller to visit all the cities in their region?",  # noqa: E501
-        )
-    ],
-)
-outputs = io_processor.create_chat_completion(inputs)
-print(f"ROLE: {outputs.next_message.content}")
-print("--------")
+question = "Find the fastest way for a seller to visit all the cities in their region"
+messages = [UserMessage(content=question)]
+outputs = io_processor.create_chat_completion(ChatCompletionInputs(messages=messages))
+print("-- NO THINKING ------")
 print(outputs.next_message.content)

--- a/examples/inference_with_thinking.py
+++ b/examples/inference_with_thinking.py
@@ -15,17 +15,15 @@ model_name = "granite3.1"
 io_processor = make_io_processor(
     model_name, backend=make_backend("openai", {"model_name": model_name})
 )
+question = "Find the fastest way for a seller to visit all the cities in their region"
+messages = [UserMessage(content=question)]
 
-# With Thinking
-inputs = ChatCompletionInputs(
-    messages=[
-        UserMessage(
-            content="What's the fastest way for a seller to visit all the cities in their region?",  # noqa: E501
-        )
-    ],
-    thinking=True,
+# Without Thinking
+outputs = io_processor.create_chat_completion(
+    ChatCompletionInputs(messages=messages, thinking=True)
 )
-outputs = io_processor.create_chat_completion(inputs)
-print(f"ROLE: {outputs.next_message.content}")
-print("--------")
+print("-- WITH THINKING ------")
+print(">> Thoughts:")
+print(outputs.reasoning_content)
+print(">> Response:")
 print(outputs.next_message.content)

--- a/src/granite_io/types.py
+++ b/src/granite_io/types.py
@@ -113,6 +113,13 @@ class ChatCompletionResult(pydantic.BaseModel):
 
     next_message: ChatMessage
 
+    def __getattr__(self, name: str) -> any:
+        """Allow attribute access for unknown attributes"""
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return None
+
 
 class GenerateResult(pydantic.BaseModel):
     """

--- a/src/granite_io/types.py
+++ b/src/granite_io/types.py
@@ -96,6 +96,13 @@ class ChatCompletionInputs(pydantic.BaseModel):
         extra="allow"
     )
 
+    def __getattr__(self, name: str) -> any:
+        """Allow attribute access for unknown attributes"""
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return None
+
 
 class ChatCompletionResult(pydantic.BaseModel):
     """

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the core types
+"""
+
+# Third Party
+import pytest
+
+# Local
+from granite_io import types
+
+
+def test_function_call():
+    fc = types.FunctionCall(id="1", name="test_func", arguments={"arg1": "value"})
+    assert fc.id == "1"
+    assert fc.name == "test_func"
+    assert fc.arguments == {"arg1": "value"}
+
+
+def test_chat_message_types():
+    um = types.UserMessage(content="user content")
+    am = types.AssistantMessage(content="assistant content", tool_calls=[])
+    trm = types.ToolResultMessage(content="tool result content", tool_call_id="123")
+    sm = types.SystemMessage(content="system content")
+
+    assert um.role == "user"
+    assert am.role == "assistant"
+    assert trm.role == "tool"
+    assert sm.role == "system"
+    assert um.to_openai_json()["role"] == "user"
+    assert am.to_openai_json()["role"] == "assistant"
+    assert trm.to_openai_json()["role"] == "tool"
+    assert sm.to_openai_json()["role"] == "system"
+
+
+def test_function_definition():
+    fd = types.FunctionDefinition(name="test_func", description="Test function")
+    assert fd.name == "test_func"
+    assert fd.description == "Test function"
+    assert fd.parameters is None
+
+    with pytest.raises(NotImplementedError):
+        fd.to_openai_json()
+
+
+def test_chat_completion_inputs():
+    cci = types.ChatCompletionInputs(messages=[])
+    assert len(cci.messages) == 0
+    assert len(cci.tools) == 0
+
+    # Setting additional attributes should work as expected
+    cci.additional_attr = "value"
+    assert hasattr(cci, "additional_attr") is True
+    assert cci.additional_attr == "value"
+
+    # Getting unknown attributes should return None
+    assert cci.foobar is None
+
+
+def test_chat_completion_result():
+    ccrr = types.ChatCompletionResult(
+        next_message=types.UserMessage(content="test message")
+    )
+    assert hasattr(ccrr, "next_message") is True
+
+    # Testing __getattr__ behavior for unknown attributes
+    assert ccrr.foobar is None
+    assert ccrr.bazbat is None
+
+
+def test_generate_result():
+    gr = types.GenerateResult(
+        completion_string="generated string",
+        completion_tokens=[1, 2, 3],
+        stop_reason="stop reason",
+    )
+    assert gr.completion_string == "generated string"
+    assert gr.completion_tokens == [1, 2, 3]
+    assert gr.stop_reason == "stop reason"


### PR DESCRIPTION
## Description

This PR introduces output parsing for granite 3.2 Chain of Thought. It also makes a few subtle architectural updates:

* It allows arbitrary attributes to be accessed on the `ChatCompletionInputs` and `ChatCompletionResult` objects and safely return `None`. This allows both IO processor implementations and user scripts to treat all derived types the same and only do `None` checks without needing a lot of `isinstance` checks or `AttributeError` handling.
* It changes the abstract interface of `ModelDirectInputOutputProcessor` so that derived classes have full control over creating the `ChatCompletionResult` object (or a derived superset type)