### PR TITLE
Remove upper band restriction on Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Granite IO Processing is a framework which enables you to transform how a user c
 
 ### Requirements
 
-* Python 3.10 to Python 3.11
+* Python 3.10+
 
 ### Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = "Input and output processing for IBM Granite models"
 readme = "README.md"
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dynamic = ["version"]

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
     unitcov: {envpython} -W error::UserWarning -m pytest --cov=granite_io --cov-report term --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests}
 
 [testenv:py3]
-basepython = python3.11
+basepython = python3.12
 
 [testenv:unit]
 basepython = {[testenv:py3]basepython}
@@ -56,5 +56,6 @@ commands =
 
 [gh]
 python =
+    3.12 = 3.12-{unitcov}
     3.11 = 3.11-{unitcov}
     3.10 = 3.10-{unitcov}


### PR DESCRIPTION
The restriction for version < 3.12 no longer applies due to vLLM is no longer started from library.