### PR TITLE
Use watsonx with LiteLLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,14 @@ To help you get up and running as quickly as possible with the Granite IO Proces
 
 > [!IMPORTANT]  
 > To get started with the examples, make sure you have followed the [Installation](#installation) steps first.
-> You will need additional packages to be able to run the OpenAI example. They can be installed by running `pip install -e "granite-io[openai]"`. Replace package name `granite-io` with `.` if installing from source.
+> You will need additional packages to be able to run the examples. They can be installed by running `pip install -e "granite-io[openai]"` and `pip install -e "granite-io[litellm]`. Replace package name `granite-io` with `.` if installing from source.
 >
 > You will also need an [Ollama](https://ollama.com/) server [running locally](https://github.com/ollama/ollama?tab=readme-ov-file#start-ollama) and [IBM Granite 3.2](https://www.ibm.com/new/announcements/ibm-granite-3-2-open-source-reasoning-and-vision) model cached (`ollama pull granite3.2:8b`).
 
 
    - [Granite 3.2 chat request](./examples/model_chat.py)
    - [Granite 3.2 chat request with thinking](./examples/inference_with_thinking.py)
+   - [Using watsonx.ai](./examples/watsonx_litellm.py)
 
 2. Jupyter notebook tutorials:
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ print(outputs.next_message.content)
 ```
 
 > [!IMPORTANT]  
-> To get started with the examples, make sure you have followed the [Installation](#installation) steps first. You will also need additional packages to be able to run the OpenAI example. They can be installed by running `pip install -e "granite-io[openai]"`. Replace package name `granite-io` with `.` if installing from source.
+> To get started with the examples, make sure you have followed the [Installation](#installation) steps first.
+> You will need additional packages to be able to run the OpenAI example. They can be installed by running `pip install -e "granite-io[openai]"`. Replace package name `granite-io` with `.` if installing from source.
 >
 > To be able to run the above code snippet, you will need an [Ollama](https://ollama.com/) server [running locally](https://github.com/ollama/ollama?tab=readme-ov-file#start-ollama) and [IBM Granite 3.2](https://www.ibm.com/granite) model cached (`ollama pull granite3.2:8b`).
 
@@ -92,7 +93,11 @@ To help you get up and running as quickly as possible with the Granite IO Proces
 1. Python script examples:
 
 > [!IMPORTANT]  
-> To get started with the examples, make sure you have followed the [Installation](#installation) steps first. You will also need an [Ollama](https://ollama.com/) server [running locally](https://github.com/ollama/ollama?tab=readme-ov-file#start-ollama) and [IBM Granite 3.2](https://www.ibm.com/new/announcements/ibm-granite-3-2-open-source-reasoning-and-vision) model cached (`ollama pull granite3.2:8b`).
+> To get started with the examples, make sure you have followed the [Installation](#installation) steps first.
+> You will need additional packages to be able to run the OpenAI example. They can be installed by running `pip install -e "granite-io[openai]"`. Replace package name `granite-io` with `.` if installing from source.
+>
+> You will also need an [Ollama](https://ollama.com/) server [running locally](https://github.com/ollama/ollama?tab=readme-ov-file#start-ollama) and [IBM Granite 3.2](https://www.ibm.com/new/announcements/ibm-granite-3-2-open-source-reasoning-and-vision) model cached (`ollama pull granite3.2:8b`).
+
 
    - [Granite 3.2 chat request](./examples/model_chat.py)
    - [Granite 3.2 chat request with thinking](./examples/inference_with_thinking.py)

--- a/examples/watsonx_litellm.py
+++ b/examples/watsonx_litellm.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This example show how to infer or call a model using the framework
+and a watsonx or ollama backend with the LiteLLM client.
+"""
+
+# Third Party
+from dotenv import load_dotenv
+
+# Local
+from granite_io import make_backend, make_io_processor
+from granite_io.types import ChatCompletionInputs, UserMessage
+
+load_dotenv()
+
+# LiteLLM will honor environment variables.
+# For this example, use a local .env file to set the variables needed
+# for watsonx or for ollama.  load_dotenv() above will read them in.
+#
+# Example .env entries:
+#
+# For watsonx:
+#
+# MODEL_NAME=watsonx/ibm/granite-3-2-8b-instruct
+# WATSONX_API_BASE=https://us-south.ml.cloud.ibm.com
+# WATSONX_PROJECT_ID=<your watsonx project ID>
+# WATSONX_API_KEY=<your watsonx api key>
+#
+# For ollama:
+#
+# MODEL_NAME="ollama/granite3.2:8b"
+# OPENAI_API_BASE=http://localhost:11434/v1
+# OPENAI_API_KEY="ollama"
+
+model_name = "Granite 3.2"
+io_processor = make_io_processor(
+    model_name,
+    backend=make_backend(
+        "litellm",
+        {
+            "model_name": "ollama/granite3.2:8b",
+        },
+    ),
+)
+question = "Find the fastest way for a seller to visit all the cities in their region"
+messages = [UserMessage(content=question)]
+outputs = io_processor.create_chat_completion(ChatCompletionInputs(messages=messages))
+print("------ WITHOUT THINKING ------")
+print(outputs.next_message.content)
+
+# With Thinking
+outputs = io_processor.create_chat_completion(
+    ChatCompletionInputs(messages=messages, thinking=True)
+)
+print("------ WITH THINKING ------")
+print(">> Thoughts:")
+print(outputs.reasoning_content)
+print(">> Response:")
+print(outputs.next_message.content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,9 @@ openai = [
 ]
 litellm = [
     "litellm",
+    "python-dotenv==1.0.1",
 ]
 dev = [
-    "python-dotenv==1.0.1",
     "isort==6.0.1",
     "pre-commit>=3.0.4,<5.0",
     "pylint>=2.16.2,<4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,11 @@ transformers = [
 openai = [
     "openai",
 ]
+litellm = [
+    "litellm",
+]
 dev = [
+    "python-dotenv==1.0.1",
     "isort==6.0.1",
     "pre-commit>=3.0.4,<5.0",
     "pylint>=2.16.2,<4.0",
@@ -54,6 +58,7 @@ dev = [
     "tox",
     "granite-io[transformers]",
     "granite-io[openai]",
+    "granite-io[litellm]",
 ]
 notebook = [
     "ipywidgets",

--- a/src/granite_io/backend/__init__.py
+++ b/src/granite_io/backend/__init__.py
@@ -8,5 +8,6 @@ models
 # Local
 from granite_io.backend.base import Backend, ChatCompletionBackend  # noqa: F401
 from granite_io.backend.registry import backend, make_backend  # noqa: F401
+import granite_io.backend.litellm  # noqa: F401
 import granite_io.backend.openai  # noqa: F401
 import granite_io.backend.transformers  # noqa: F401

--- a/src/granite_io/backend/litellm.py
+++ b/src/granite_io/backend/litellm.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+# Standard
+from typing import TYPE_CHECKING
+
+# Third Party
+import aconfig
+
+# Local
+from granite_io.backend.base import Backend
+from granite_io.backend.registry import backend
+from granite_io.optional import import_optional
+from granite_io.types import GenerateResult
+
+if TYPE_CHECKING:
+    # Third Party
+    pass
+
+
+@backend(
+    "litellm",
+    config_schema={
+        "properties": {
+            "model_name": {"type": "string"},
+            # "openai_base_url": {"type": "string"},
+            # "openai_api_key": {"type": "string"},
+        }
+    },
+)
+class LiteLLMBackend(Backend):
+    _model_str: str
+
+    def __init__(self, config: aconfig.Config):
+        self._model_str = config.model_name
+
+    def generate(self, input_str: str) -> GenerateResult:
+        """Run a direct /completions call"""
+
+        # Import packages from extras "transformers"
+        with import_optional("litellm"):
+            # Third Party
+            import litellm
+
+        # litellm._turn_on_debug()
+
+        result = litellm.text_completion(
+            # model strings start with provider/
+            # model="watsonx/ibm/granite-3-2-8b-instruct",
+            # model="ollama/llama3.1:latest",
+            model=self._model_str,
+            prompt=input_str,
+        )
+        return GenerateResult(
+            completion_string=result.choices[0].text,
+            completion_tokens=[],  # Not part of the OpenAI spec
+            stop_reason=result.choices[0].finish_reason,
+        )

--- a/src/granite_io/backend/litellm.py
+++ b/src/granite_io/backend/litellm.py
@@ -15,7 +15,7 @@ from granite_io.types import GenerateResult
 
 if TYPE_CHECKING:
     # Third Party
-    import litellm
+    import litellm  # noqa: F401
 
 
 @backend(

--- a/src/granite_io/backend/litellm.py
+++ b/src/granite_io/backend/litellm.py
@@ -15,7 +15,7 @@ from granite_io.types import GenerateResult
 
 if TYPE_CHECKING:
     # Third Party
-    pass
+    import litellm
 
 
 @backend(
@@ -37,12 +37,9 @@ class LiteLLMBackend(Backend):
     def generate(self, input_str: str) -> GenerateResult:
         """Run a direct /completions call"""
 
-        # Import packages from extras "transformers"
         with import_optional("litellm"):
             # Third Party
             import litellm
-
-        # litellm._turn_on_debug()
 
         result = litellm.text_completion(
             # model strings start with provider/

--- a/tests/io/test_granite_3_2.py
+++ b/tests/io/test_granite_3_2.py
@@ -228,7 +228,7 @@ def test_run_transformers(
 
 
 @pytest.mark.xfail(
-    reason="will xfail if APIConnectionError because LiteLLM tests are optional",
+    reason="will xfail if APIConnectionError because OpenAI tests are optional",
     raises=APIConnectionError,
 )
 def test_run_openai(
@@ -242,7 +242,7 @@ def test_run_openai(
 
 
 @pytest.mark.xfail(
-    reason="will xfail if APIConnectionError because OpenAI tests are optional",
+    reason="will xfail if APIConnectionError because LiteLLM tests are optional",
     raises=ACE,
 )
 def test_run_litellm(

--- a/tests/io/test_granite_3_2.py
+++ b/tests/io/test_granite_3_2.py
@@ -7,6 +7,7 @@
 import json
 
 # Third Party
+from litellm import APIConnectionError as ACE
 from openai import APIConnectionError
 import pytest
 import torch
@@ -98,6 +99,22 @@ def io_processor_openai() -> Granite3Point2InputOutputProcessor:
         "openai",
         {
             "model_name": "granite3.2:2b",
+            "openai_api_key": "ollama",
+            "openai_base_url": "http://localhost:11434/v1",
+        },
+    )
+    # The io factory requires a known model name
+    return make_io_processor(_MODEL_NAME, backend=backend)
+
+
+@pytest.fixture
+def io_processor_litellm() -> Granite3Point2InputOutputProcessor:
+    # The backend factory requires a known backend name
+    # You can override config with env vars, but only known config vars
+    backend = make_backend(
+        "litellm",
+        {
+            "model_name": "ollama/granite3.2:2b",
             "openai_api_key": "ollama",
             "openai_base_url": "http://localhost:11434/v1",
         },
@@ -211,7 +228,7 @@ def test_run_transformers(
 
 
 @pytest.mark.xfail(
-    reason="xfail if APIConnectionError because OpenAI tests are optional",
+    reason="will xfail if APIConnectionError because LiteLLM tests are optional",
     raises=APIConnectionError,
 )
 def test_run_openai(
@@ -219,6 +236,20 @@ def test_run_openai(
 ):
     inputs = ChatCompletionInputs.model_validate_json(input_json_str)
     _ = io_processor_openai.create_chat_completion(inputs)
+
+    # TODO: Once the prerelease model has settled down and we have implemented
+    # temperature controls, verify outputs
+
+
+@pytest.mark.xfail(
+    reason="will xfail if APIConnectionError because OpenAI tests are optional",
+    raises=ACE,
+)
+def test_run_litellm(
+    io_processor_litellm: Granite3Point2InputOutputProcessor, input_json_str: str
+):
+    inputs = ChatCompletionInputs.model_validate_json(input_json_str)
+    _ = io_processor_litellm.create_chat_completion(inputs)
 
     # TODO: Once the prerelease model has settled down and we have implemented
     # temperature controls, verify outputs

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ wheel_build_env = pkg
 passenv =
     MODEL_NAME
     OPENAI_*
+    WATSONX_*
 setenv =
     HF_HUB_OFFLINE=1
     HF_HOME=~/.cache/huggingface


### PR DESCRIPTION
LiteLLM supports watsonx, ollama and others.  I could not get it to work with RITS so it is yet another limited proxy for backend providers (otherwise maybe it would replace our openai backend).

LiteLLM uses environment variables for much of the control over backends, so there is a new example using a .env file to show how to make the example work with either watsonx or ollama.