### PR TITLE
CoT robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ outputs = io_processor.create_chat_completion(
 )
 print("------ WITH THINKING ------")
 print(">> Thoughts:")
-print(outputs.reasoning_content)
+print(outputs.next_message.reasoning_content)
 print(">> Response:")
 print(outputs.next_message.content)
 ```
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > To get started with the examples, make sure you have followed the [Installation](#installation) steps first.
 > You will need additional packages to be able to run the OpenAI example. They can be installed by running `pip install -e "granite-io[openai]"`. Replace package name `granite-io` with `.` if installing from source.
 >
@@ -92,12 +92,11 @@ To help you get up and running as quickly as possible with the Granite IO Proces
 
 1. Python script examples:
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > To get started with the examples, make sure you have followed the [Installation](#installation) steps first.
 > You will need additional packages to be able to run the examples. They can be installed by running `pip install -e "granite-io[openai]"` and `pip install -e "granite-io[litellm]`. Replace package name `granite-io` with `.` if installing from source.
 >
 > You will also need an [Ollama](https://ollama.com/) server [running locally](https://github.com/ollama/ollama?tab=readme-ov-file#start-ollama) and [IBM Granite 3.2](https://www.ibm.com/new/announcements/ibm-granite-3-2-open-source-reasoning-and-vision) model cached (`ollama pull granite3.2:8b`).
-
 
    - [Granite 3.2 chat request](./examples/model_chat.py)
    - [Granite 3.2 chat request with thinking](./examples/inference_with_thinking.py)
@@ -105,7 +104,7 @@ To help you get up and running as quickly as possible with the Granite IO Proces
 
 2. Jupyter notebook tutorials:
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > To get started with the examples, make sure you have followed the [Installation](#installation) steps first. You will also need additional packages to be able to run the Jupyter notebook. They can be installed by running `pip install -e "granite-io[transformers]"` and `pip install -e "granite-io[notebook]"`. Replace package name `granite-io` with `.` if installing from source. The notebooks can be then run with following command `jupyter notebook <path_to_notebook>`.
 
    - [IO](./notebooks/io.ipynb)

--- a/examples/model_chat_with_thinking.py
+++ b/examples/model_chat_with_thinking.py
@@ -24,6 +24,6 @@ outputs = io_processor.create_chat_completion(
 )
 print("------ WITH THINKING ------")
 print(">> Thoughts:")
-print(outputs.reasoning_content)
+print(outputs.next_message.reasoning_content)
 print(">> Response:")
 print(outputs.next_message.content)

--- a/src/granite_io/io/granite_3_2.py
+++ b/src/granite_io/io/granite_3_2.py
@@ -571,10 +571,8 @@ class Granite3Point2InputOutputProcessor(ModelDirectInputOutputProcessor):
                     break
 
             if cot_start_span and cot_end_span and cot_end_span[0] > cot_start_span[1]:
-                cot = output[cot_start_span[1] : cot_end_span[0]].lstrip("\n")
-                output = output[: cot_start_span[0]] + output[cot_end_span[1] :].lstrip(
-                    "\n"
-                )
+                cot = output[cot_start_span[1] : cot_end_span[0]].strip()
+                output = output[: cot_start_span[0]] + output[cot_end_span[1] :].strip()
 
         # Parse out tool calls
         if output.startswith("<tool_call>"):
@@ -584,6 +582,6 @@ class Granite3Point2InputOutputProcessor(ModelDirectInputOutputProcessor):
             next_message=AssistantMessage(
                 content=output,
                 reasoning_content=cot,
-                _raw=original_output,
+                raw=original_output,
             )
         )

--- a/src/granite_io/io/granite_3_2.py
+++ b/src/granite_io/io/granite_3_2.py
@@ -76,6 +76,17 @@ available data."""
 _COT_START = "Here is my thought process:"
 _COT_END = "Here is my response:"
 
+# Some versions of the model are known to shorten "Here is" to "Here's", so we
+# provide alternate forms of these strings for those versions.
+_COT_START_ALTERNATIVES = [
+    _COT_START,
+    "Here's my thought process:",
+]
+_COT_END_ALTERNATIVES = [
+    _COT_END,
+    "Here's my response:",
+]
+
 # String that a Granite 3.2 model must receive immediately after _SYSTEM_MESSAGE_START
 # if there are no tools or documents in the current request and the "thinking" flag is
 # set to `True`.
@@ -191,14 +202,6 @@ class _Granite3Point2Inputs(ChatCompletionInputs):
         # TODO: Validate this invariant.
 
         return messages
-
-
-class _Granite3Point2ChatCompletionResult(ChatCompletionResult):
-    """
-    Chat completion result type for granite 3.2 language models
-    """
-
-    reasoning_content: str | None
 
 
 @io_processor(
@@ -551,21 +554,36 @@ class Granite3Point2InputOutputProcessor(ModelDirectInputOutputProcessor):
         self,
         output: str,
         inputs: ChatCompletionInputs | None = None,
-    ) -> _Granite3Point2ChatCompletionResult:
-        cot = None
-
+    ) -> ChatCompletionResult:
         # Parse out CoT reasoning
+        cot = None
+        original_output = output
         if inputs.thinking:
-            cot_start = output.find(_COT_START)
-            cot_end = output.find(_COT_END)
-            if -1 not in [cot_start, cot_end]:
-                cot = output[cot_start + len(_COT_START) : cot_end]
-                output = output[:cot_start] + output[cot_end + len(_COT_END) :]
+            cot_start_span = None
+            cot_end_span = None
+            for cot_start_str in _COT_START_ALTERNATIVES:
+                if (cot_start_pos := output.find(cot_start_str)) != -1:
+                    cot_start_span = (cot_start_pos, cot_start_pos + len(cot_start_str))
+                    break
+            for cot_end_str in _COT_END_ALTERNATIVES:
+                if (cot_end_pos := output.find(cot_end_str)) != -1:
+                    cot_end_span = (cot_end_pos, cot_end_pos + len(cot_end_str))
+                    break
+
+            if cot_start_span and cot_end_span and cot_end_span[0] > cot_start_span[1]:
+                cot = output[cot_start_span[1] : cot_end_span[0]].lstrip("\n")
+                output = output[: cot_start_span[0]] + output[cot_end_span[1] :].lstrip(
+                    "\n"
+                )
 
         # Parse out tool calls
         if output.startswith("<tool_call>"):
             raise NotImplementedError("TODO: Implement tool call parsing")
 
-        return _Granite3Point2ChatCompletionResult(
-            next_message=AssistantMessage(content=output), reasoning_content=cot
+        return ChatCompletionResult(
+            next_message=AssistantMessage(
+                content=output,
+                reasoning_content=cot,
+                _raw=original_output,
+            )
         )

--- a/src/granite_io/types.py
+++ b/src/granite_io/types.py
@@ -49,6 +49,10 @@ class AssistantMessage(_ChatMessageBase):
     # Raw response content without any parsing for re-serialization
     _raw: str | None = None
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._raw = kwargs.pop("raw", None)
+
     @property
     def raw(self) -> str:
         """Get the raw content of the response"""

--- a/src/granite_io/types.py
+++ b/src/granite_io/types.py
@@ -45,6 +45,14 @@ class UserMessage(_ChatMessageBase):
 class AssistantMessage(_ChatMessageBase):
     role: Literal["assistant"] = "assistant"
     tool_calls: list[FunctionCall] = []
+    reasoning_content: str | None = None
+    # Raw response content without any parsing for re-serialization
+    _raw: str | None = None
+
+    @property
+    def raw(self) -> str:
+        """Get the raw content of the response"""
+        return self._raw if self._raw is not None else self.content
 
 
 class ToolResultMessage(_ChatMessageBase):

--- a/tests/io/test_granite_3_2.py
+++ b/tests/io/test_granite_3_2.py
@@ -16,12 +16,18 @@ import transformers
 # Local
 from granite_io import make_backend, make_io_processor
 from granite_io.io.granite_3_2 import (
+    _COT_END,
+    _COT_END_ALTERNATIVES,
+    _COT_START,
+    _COT_START_ALTERNATIVES,
     _MODEL_NAME,
     GRANITE_3_2_2B_HF,
     Granite3Point2InputOutputProcessor,
     _Granite3Point2Inputs,
 )
 from granite_io.types import AssistantMessage, ChatCompletionInputs, UserMessage
+
+## Helpers #####################################################################
 
 # All the different chat completion requests that are tested in this file, serialized as
 # JSON strings. Represented as a dictionary instead of a list so that pytest output will
@@ -121,6 +127,28 @@ def io_processor_litellm() -> Granite3Point2InputOutputProcessor:
     )
     # The io factory requires a known model name
     return make_io_processor(_MODEL_NAME, backend=backend)
+
+
+msg = UserMessage(content="Hello")
+no_thinking_input = ChatCompletionInputs(messages=[msg])
+thinking_input = ChatCompletionInputs(messages=[msg], thinking=True)
+
+thought = "Think think"
+response = "respond respond"
+pre_thought = "something before"
+no_cot_output = f"{thought} {response}"
+no_thinking_output = f"{thought} {_COT_END} {response}"
+no_response_output = f"{_COT_START}\n\n{response}"
+cot_output = f"{_COT_START}\n\n{thought}\n{_COT_END}\n\n{response}"
+cot_alt_output = f"{_COT_START_ALTERNATIVES[-1]}\n\n{thought}\n{_COT_END_ALTERNATIVES[-1]}\n\n{response}"
+cot_mixed_output = (
+    f"{_COT_START}\n\n{thought}\n{_COT_END_ALTERNATIVES[-1]}\n\n{response}"
+)
+cot_pre_output = (
+    f"{pre_thought} {_COT_START} {thought} {_COT_END_ALTERNATIVES[-1]} {response}"
+)
+
+## Tests #######################################################################
 
 
 def test_read_inputs(input_json_str):
@@ -253,3 +281,28 @@ def test_run_litellm(
 
     # TODO: Once the prerelease model has settled down and we have implemented
     # temperature controls, verify outputs
+
+
+@pytest.mark.parametrize(
+    ["inputs", "output", "exp_thought", "exp_resp"],
+    [
+        # No thinking flag
+        (no_thinking_input, no_thinking_output, None, no_thinking_output),
+        (no_thinking_input, cot_output, None, cot_output),
+        # Thinking flag
+        (thinking_input, no_cot_output, None, no_cot_output),
+        (thinking_input, no_thinking_output, None, no_thinking_output),
+        (thinking_input, no_response_output, None, no_response_output),
+        (thinking_input, cot_output, thought, response),
+        (thinking_input, cot_alt_output, thought, response),
+        (thinking_input, cot_mixed_output, thought, response),
+        (thinking_input, cot_pre_output, thought, f"{pre_thought} {response}"),
+    ],
+)
+def test_cot_parsing(inputs, output, exp_thought, exp_resp):
+    """Test the parsing logic for CoT reasoning output"""
+    proc = Granite3Point2InputOutputProcessor()
+    result = proc.output_to_result(output, inputs).next_message
+    assert result.reasoning_content == exp_thought
+    assert result.content == exp_resp
+    assert result.raw == output


### PR DESCRIPTION
Closes #20 

This PR addresses the outstanding issues from the original CoT parsing PR that we opted to defer to after-release. Specifically, it does the following:

* Moves the `reasoning_content` field into the `next_message`
* Adds the `raw` logical-field to `AssistantMessage`
* Adds robustness for different forms of the CoT tags
* Applies stripping to reasoning / result content for Granite 3.2, relying on `.raw` for round-trip serialization