### PR TITLE
ci: test examples when code changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ on:
       - '**.py'
       - 'pyproject.toml'
       - 'tox.ini'
-      - 'scripts/*.sh' # Used by this workflow
       - '.github/workflows/test.yml' # This workflow
   pull_request:
     branches:
@@ -20,7 +19,6 @@ on:
       - '**.py'
       - 'pyproject.toml'
       - 'tox.ini'
-      - 'scripts/*.sh' # Used by this workflow
       - '.github/workflows/test.yml' # This workflow
 
 env:

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -7,12 +7,20 @@ on:
       - "main"
       - "release-**"
     paths:
+      - 'src/**.py'
+      - 'examples/**.py'
+      - 'pyproject.toml'
+      - 'tox.ini'
       - '.github/workflows/test_examples.*' # This workflow
   pull_request:
     branches:
       - "main"
       - "release-**"
     paths:
+      - 'src/**.py'
+      - 'examples/**.py'
+      - 'pyproject.toml'
+      - 'tox.ini'
       - '.github/workflows/test_examples.*' # This workflow
 
 env:


### PR DESCRIPTION
paths was restricting when the test runs. It should run anytime code changes that might break the examples.