### PR TITLE
Fix failing unit test

### DIFF
--- a/tests/io/granite_3_2/input_processors/test_granite_3_2_input_processor.py
+++ b/tests/io/granite_3_2/input_processors/test_granite_3_2_input_processor.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from pathlib import Path
 import os
 
 # Local
@@ -10,14 +9,10 @@ from granite_io.types import (
     ChatCompletionInputs,
     UserMessage,
 )
+from tests.test_utils import load_text_file
 
 _GENERALE_MODEL_NAME = "Granite 3.2"
 _TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
-
-
-def _load_model_output_file(file_name: str) -> str:
-    response = Path(file_name).read_text(encoding="UTF-8")
-    return response
 
 
 def test_run_processor_reasoning():
@@ -30,8 +25,21 @@ def test_run_processor_reasoning():
         ChatCompletionInputs(messages=messages, thinking=True)
     )
 
-    expected_prompt = _load_model_output_file(
+    expected_prompt = load_text_file(
         os.path.join(_TEST_DATA_DIR, "test_reasoning_prompt.txt")
     )
     assert isinstance(prompt, str)
-    assert prompt == expected_prompt
+    assert len(prompt) == len(expected_prompt)
+
+    # Prompt contains dates in first two lines of the text which change.
+    # Therefore need to extract and test them separately first.
+    # Then we test the remaining text.
+    assert (
+        prompt.split("\n", 1)[0].split(":")[0]
+        == (expected_prompt.split("\n", 1)[0].split(":")[0])
+    )
+    assert (
+        prompt.split("\n", 1)[1].split(":")[0]
+        == (expected_prompt.split("\n", 1)[1].split(":")[0])
+    )
+    assert prompt.split("\n", 2)[-1] == expected_prompt.split("\n", 2)[-1]

--- a/tests/io/granite_3_2/output_processors/test_granite_3_2_output_parser.py
+++ b/tests/io/granite_3_2/output_processors/test_granite_3_2_output_parser.py
@@ -5,7 +5,6 @@ Tests for the model output parser
 """
 
 # Standard
-from pathlib import Path
 import os
 
 # Local
@@ -15,19 +14,13 @@ from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor impo
 from granite_io.io.granite_3_2.output_processors.granite_3_2_output_parser import (
     parse_model_output,
 )
+from tests.test_utils import load_text_file
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
 
 
-def _load_model_output_file(file_name: str) -> str:
-    response = Path(file_name).read_text(encoding="UTF-8")
-    return response
-
-
 def test_output():
-    model_output = _load_model_output_file(
-        os.path.join(TEST_DATA_DIR, "test_output.txt")
-    )
+    model_output = load_text_file(os.path.join(TEST_DATA_DIR, "test_output.txt"))
     parsed_output = parse_model_output(model_output, "")
 
     assert parsed_output
@@ -46,7 +39,7 @@ def test_output():
 
 
 def test_output_with_citation():
-    model_output = _load_model_output_file(
+    model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_citation.txt")
     )
     parsed_output = parse_model_output(model_output, "")
@@ -98,7 +91,7 @@ def test_output_with_citation():
 
 
 def test_output_with_invalid_citation():
-    model_output = _load_model_output_file(
+    model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_invalid_citation.txt")
     )
     parsed_output = parse_model_output(model_output, "")
@@ -109,7 +102,7 @@ def test_output_with_invalid_citation():
 
 
 def test_output_with_citation_hallucinations():
-    model_output = _load_model_output_file(
+    model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_citation_hallucinations.txt")
     )
     parsed_output = parse_model_output(model_output, "")
@@ -177,12 +170,10 @@ def test_output_with_citation_hallucinations():
 
 
 def test_output_with_citation_from_source():
-    model_output = _load_model_output_file(
+    model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_citation_from_source.txt")
     )
-    doc_source = _load_model_output_file(
-        os.path.join(TEST_DATA_DIR, "test_document_source.txt")
-    )
+    doc_source = load_text_file(os.path.join(TEST_DATA_DIR, "test_document_source.txt"))
     doc_input = [_Document(text=f"{doc_source}")]
     parsed_output = parse_model_output(model_output, doc_input)
 

--- a/tests/io/granite_3_2/output_processors/test_granite_3_2_output_processor.py
+++ b/tests/io/granite_3_2/output_processors/test_granite_3_2_output_processor.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from pathlib import Path
 import os
 
 # Local
@@ -12,21 +11,17 @@ from granite_io.types import (
     GenerateResults,
     UserMessage,
 )
+from tests.test_utils import load_text_file
 
 _GENERAL_MODEL_NAME = "Granite 3.2"
 _TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
-
-
-def _load_model_output_file(file_name: str) -> str:
-    response = Path(file_name).read_text(encoding="UTF-8")
-    return response
 
 
 def test_run_processor_reasoning():
     output_processor = get_output_processor(_GENERAL_MODEL_NAME)
     # Process the output
     results = []
-    raw_output = _load_model_output_file(
+    raw_output = load_text_file(
         os.path.join(_TEST_DATA_DIR, "test_raw_reasoning_output.txt")
     )
     results.append(
@@ -45,12 +40,12 @@ def test_run_processor_reasoning():
         ChatCompletionInputs(messages=messages, thinking=True),
     )
 
-    expected_thought_output = _load_model_output_file(
+    expected_thought_output = load_text_file(
         os.path.join(_TEST_DATA_DIR, "test_reasoning_output_processor_thought.txt")
     )
     assert expected_thought_output == outputs.results[0].next_message.reasoning_content
 
-    expected_response_output = _load_model_output_file(
+    expected_response_output = load_text_file(
         os.path.join(_TEST_DATA_DIR, "test_reasoning_output_processor_response.txt")
     )
     assert expected_response_output == outputs.results[0].next_message.content

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+
+
+def load_text_file(file_name: str) -> str:
+    text = Path(file_name).read_text(encoding="UTF-8")
+    return text


### PR DESCRIPTION
Failing test:
`tests/io/granite_3_2/input_processors/test_granite_3_2_input_processor.py::test_run_processor_reasoning`

This commit fixes the test and also adds a function for loading test text file used by multiple tests.