### PR TITLE
dev: Updates to development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,9 @@ htmlcov/
 .coverage
 .coverage.*
 durations/*
-coverage*.xml
 .cache
 nosetests.xml
+coverage.xml
 *.cover
 *.py,cover
 .hypothesis/
@@ -95,6 +95,12 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
@@ -107,8 +113,10 @@ ipython_config.py
 #pdm.lock
 #   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
 #   in version control.
-#   https://pdm.fming.dev/#use-with-ide
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
 .pdm.toml
+.pdm-python
+.pdm-build/
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
@@ -158,10 +166,17 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-.idea/
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Mac personalization files
+*.DS_Store
 
 # Setuptools scm version
 /src/granite_io/_version.py
 
-# Mac personalization files
-*.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,11 +52,17 @@ The following tools are required:
 - [python](https://www.python.org) (v3.10)
 - [pip](https://pypi.org/project/pip/) (v23.0+)
 
-You can setup your dev environment using `tox`, an environment orchestrator which allows for setting up environments for and invoking builds, unit tests, formatting, linting, etc. Install `tox` with:
+The first step is to install the necessary Python packages required for development. The command to do this is as follows:
 
 ```shell
-pip install tox
+pip install -e ".[dev]"
 ```
+
+> [!NOTE]
+> The `[all]` target can be used to install all packages `dev` and `notebook` with following command:
+> `pip install -e ".[all]"`
+
+You can run your dev environment using [tox](https://tox.wiki), which is an environment orchestrator that allows for setting up environments for and invoking builds, unit tests, formatting, linting, etc. `tox` is installed when you install the `dev` target in the `pip install` command above.
 
 If you want to manage your own virtual environment instead of using `tox`, you can install granite io processing and all dependencies. Check out [README](./README.md) for more details.
 

--- a/notebooks/.gitignore
+++ b/notebooks/.gitignore
@@ -1,3 +1,0 @@
-# Temporary notebooks for testing
-temp_*.ipynb
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "isort==6.0.1",
     "pre-commit>=3.0.4,<5.0",
     "pylint>=2.16.2,<4.0",
+    "pylint_pydantic",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",


### PR DESCRIPTION
Updates as follows:

- Realign `.gitignore` file with [Python standard](https://github.com/github/gitignore/blob/main/Python.gitignore)
- Updated contributing guide to add installing `dev` package dependencies (fixes #33)
- Remove `.gitignore` file in `notebooks` directory. Entry doesn't look like it needs to be added to main ignore file.
- Linting warning on `pylint_pydantic` package:

```shell
Command line or configuration file:1:0: E0013: Plugin 'pylint_pydantic' is impossible to load, is it installed ? ('No module named 'pylint_pydantic'') (bad-plugin-value)
```