### PR TITLE
fix: pin litellm, openai and pydantic to compatible versions

### DIFF
--- a/examples/watsonx_litellm.py
+++ b/examples/watsonx_litellm.py
@@ -50,11 +50,6 @@ io_processor = make_io_processor(
 question = "Find the fastest way for a seller to visit all the cities in their region"
 messages = [UserMessage(content=question)]
 
-# Without Thinking
-outputs = io_processor.create_chat_completion(ChatCompletionInputs(messages=messages))
-print("------ WITHOUT THINKING ------")
-print(outputs.results[0].next_message.content)
-
 # With Thinking
 outputs = io_processor.create_chat_completion(
     ChatCompletionInputs(messages=messages, thinking=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "alchemy-config",
     "jsonschema",
     "nltk",
-    "pydantic",
+    "pydantic >= 2.0.0",  # LiteLLM requires >= 2
 ]
 
 [project.optional-dependencies]
@@ -40,10 +40,10 @@ transformers = [
     "transformers[torch]",
 ]
 openai = [
-    "openai",
+    "openai >= 1.0, <= 1.61.0",  # Later verions introduce LiteLLM logging bug
 ]
 litellm = [
-    "litellm",
+    "litellm > 1.40.14, <= 1.63.2",  # Later versions introduce LiteLLM logging bug
     "python-dotenv==1.1.0",
 ]
 voting = [


### PR DESCRIPTION
Closes: #91

The main issue is logging errors (after an error) with latest litellm and openai. Also setting pydantic minimum version to be compatible with litellm.