### PR TITLE
feat: add example for how to use Replicate

### DIFF
--- a/examples/watsonx_litellm.py
+++ b/examples/watsonx_litellm.py
@@ -2,7 +2,9 @@
 
 """
 This example show how to infer or call a model using the framework
-and a watsonx or ollama backend with the LiteLLM client.
+and a watsonx, Replicate, or Ollama backend with the LiteLLM client.
+In this scenario the chat request enables thinking mode in the model
+to provide better understanding of how the model arrived at its answer.
 """
 
 # Third Party
@@ -16,9 +18,9 @@ load_dotenv()
 
 # LiteLLM will honor environment variables.
 # For this example, use a local .env file to set the variables needed
-# for watsonx or for ollama.  load_dotenv() above will read them in.
+# for watsonx or Replicate or Ollama.  load_dotenv() above will read them in.
 #
-# Example .env entries:
+# Example .env entries (choose one provider):
 #
 # For watsonx:
 #
@@ -27,24 +29,28 @@ load_dotenv()
 # WATSONX_PROJECT_ID=<your watsonx project ID>
 # WATSONX_API_KEY=<your watsonx api key>
 #
-# For ollama:
+# For Replicate:
+#
+# REPLICATE_API_TOKEN=<your Replicate api key>
+# MODEL_NAME=replicate/ibm-granite/granite-3.2-8b-instruct
+
+# For Ollama:
 #
 # MODEL_NAME="ollama/granite3.2:8b"
 # OPENAI_API_BASE=http://localhost:11434/v1
 # OPENAI_API_KEY="ollama"
 
-model_name = "Granite 3.2"
+# NOTE! If you don't specify any of the above, the Ollama defaults are used.
+
+model_type = "Granite 3.2"
+model_name = "ollama/granite3.2:8b"
 io_processor = make_io_processor(
-    model_name,
-    backend=make_backend(
-        "litellm",
-        {
-            "model_name": "ollama/granite3.2:8b",
-        },
-    ),
+    model_type, backend=make_backend("litellm", {"model_name": model_name})
 )
 question = "Find the fastest way for a seller to visit all the cities in their region"
 messages = [UserMessage(content=question)]
+
+# Without Thinking
 outputs = io_processor.create_chat_completion(ChatCompletionInputs(messages=messages))
 print("------ WITHOUT THINKING ------")
 print(outputs.results[0].next_message.content)
@@ -55,6 +61,6 @@ outputs = io_processor.create_chat_completion(
 )
 print("------ WITH THINKING ------")
 print(">> Thoughts:")
-print(outputs.results[0].reasoning_content)
+print(outputs.results[0].next_message.reasoning_content)
 print(">> Response:")
 print(outputs.results[0].next_message.content)


### PR DESCRIPTION
We can use LiteLLM to access Replicate

The examples/watsonx_litellm.py explains how to use environment variables to make LiteLLM work with watsonx, Ollama, and now Replicate (with a thinking/non-thinking example).

This example filename is not great, but emphasizing watsonx is OK. Need to follow-up with better docs explaining what is supported and link to examples from there. Separate issue coming for that.

Closes: #90 