### PR TITLE
bug: remove httpx dependency and timeout field

### DIFF
--- a/src/granite_io/types.py
+++ b/src/granite_io/types.py
@@ -10,7 +10,6 @@ from typing import Any, List, Optional, Union
 
 # Third Party
 from typing_extensions import Literal, TypeAlias
-import httpx
 import pydantic
 
 
@@ -148,7 +147,6 @@ class GenerateInputs(pydantic.BaseModel):
     temperature: The temperature parameter for controlling the randomness of the output.
     top_p: The top-p parameter for nucleus sampling.
     user: A unique identifier representing your end-user.
-    timeout: The maximum execution time in seconds for the completion request.
     """
 
     prompt: Optional[Union[str, List[Union[str, List[Union[str, List[int]]]]]]] = None
@@ -168,7 +166,6 @@ class GenerateInputs(pydantic.BaseModel):
     temperature: Optional[float] = None
     top_p: Optional[float] = None
     user: Optional[str] = None
-    timeout: Optional[Union[float, str, httpx.Timeout]] = None
 
     model_config = pydantic.ConfigDict(
         # Pass through arbitrary additional keyword arguments for handling by model- or


### PR DESCRIPTION
To support timeout for openai and litellm, I introduced an httpx dependency that we don't want in io.  We can remove timeout field since we don't add any value with it (would only limit it's httpx features).

This should fall into "other params" that we don't want to have an opinion about.  If/when we do care, we'll need to handle httpx in/out for this dataclass in an import optional way.

Closes: #84 