### PR TITLE
fix: need to wrap stop string as array in some cases

### DIFF
--- a/src/granite_io/backend/base.py
+++ b/src/granite_io/backend/base.py
@@ -71,6 +71,10 @@ class Backend(FactoryConstructible):
                 if best_of is None or best_of < n:
                     inputs.best_of = n
 
+        # Some backends prefer array (throw errors)
+        if isinstance(inputs.stop, str):
+            inputs.stop = [inputs.stop]
+
         return inputs
 
     @abc.abstractmethod


### PR DESCRIPTION
* Some combinations of provider/backend have thrown errors when stop is a string instead of array of strings. We can always make it an array.