### PR TITLE
fix: Granite 3.2 parser error - colon in citation text

### DIFF
--- a/tests/io/granite_3_2/output_processors/test_granite_3_2_output_parser.py
+++ b/tests/io/granite_3_2/output_processors/test_granite_3_2_output_parser.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E501
 
 """
 Tests for the model output parser
@@ -99,6 +100,71 @@ def test_output_with_invalid_citation():
     assert parsed_output["docs"] is None
     assert parsed_output["citations"] is None
     assert parsed_output["hallucinations"] is None
+
+
+def test_output_with_colons_in_citation_text():
+    model_output = load_text_file(
+        os.path.join(TEST_DATA_DIR, "test_output_with_colons_citation_text.txt")
+    )
+    parsed_output = parse_model_output(model_output, "")
+
+    assert parsed_output
+    assert isinstance(parsed_output, dict)
+    keys = ["docs", "response", "citations", "hallucinations"]
+    for key in keys:
+        assert key in parsed_output
+
+    docs = parsed_output["docs"]
+    assert len(docs) == 1
+    doc = docs[0]  # pylint: disable = unsubscriptable-object
+    keys = ["doc_id", "text"]
+    for key in keys:
+        assert key in doc
+    assert doc["doc_id"] == "2"
+    assert (
+        "3부 : [UNK] [UNK] 종료 [UNK], 공영 주택의 세입자는 이 프로그램에서 [UNK] [UNK] 종료에 직면합니다. 이 2가지 상황에 대해 더 자세"
+        in doc["text"]
+    )
+
+    response = parsed_output["response"]
+    assert isinstance(response, str)
+    assert "Yes, you can visit a law library to conduct your legal research" in response
+
+    citations = parsed_output["citations"]
+    assert len(citations) == 1
+    citation = citations[0]
+    keys = [
+        "citation_id",
+        "doc_id",
+        "context_text",
+        "context_begin",
+        "context_end",
+        "response_text",
+        "response_begin",
+        "response_end",
+    ]
+    for key in keys:
+        assert key in citation
+    assert citation["citation_id"] == "1"
+    assert citation["doc_id"] == "2"
+    assert len(citation["context_text"]) >= 1
+
+    hallucinations = parsed_output["hallucinations"]
+    assert len(hallucinations) == 4
+    hallc_id = 1
+    for hallucination in hallucinations:
+        keys = [
+            "hallucination_id",
+            "risk",
+            "response_text",
+            "response_begin",
+            "response_end",
+        ]
+        for key in keys:
+            assert key in hallucination
+        assert hallucination["hallucination_id"] == str(hallc_id)
+        assert len(hallucination["response_text"]) >= 1
+        hallc_id += 1
 
 
 def test_output_with_citation_hallucinations():

--- a/tests/io/granite_3_2/output_processors/test_granite_3_2_output_parser.py
+++ b/tests/io/granite_3_2/output_processors/test_granite_3_2_output_parser.py
@@ -97,7 +97,6 @@ def test_output_with_invalid_citation():
     )
     parsed_output = parse_model_output(model_output, "")
 
-    assert parsed_output["docs"] is None
     assert parsed_output["citations"] is None
     assert parsed_output["hallucinations"] is None
 

--- a/tests/io/granite_3_2/output_processors/testdata/test_output_with_colons_citation_text.txt
+++ b/tests/io/granite_3_2/output_processors/testdata/test_output_with_colons_citation_text.txt
@@ -1,0 +1,10 @@
+Yes, you can visit a law library to conduct your legal research. According to the information I have, law libraries often contain self-help legal books designed for non-lawyers, which provide tips on handling cases <co>1</co>. They also offer access to laws and court precedents, practice guides written for lawyers, and sometimes even printers for printing out necessary forms. To find a local law library near you, I recommend checking the resources listed in the document provided, such as those in Alameda, Orange, Amador, and Placer counties.
+
+# Citations:
+<co>1</co> Document 2: "3부 : [UNK] [UNK] 종료 [UNK], 공영 주택의 세입자는 이 프로그램에서 [UNK] [UNK] 종료에 직면합니다. 이 2가지 상황에 대해 더 자세"
+
+# Hallucinations:
+1. Risk low: Yes, you can visit a law library to conduct your legal research.
+2. Risk low: According to the information I have, law libraries often contain self-help legal books designed for non-lawyers, which provide tips on handling cases <co>1</co>.
+3. Risk low: They also offer access to laws and court precedents, practice guides written for lawyers, and sometimes even printers for printing out necessary forms.
+4. Risk low: To find a local law library near you, I recommend checking the resources listed in the document provided, such as those in Alameda, Orange, Amador, and Placer counties.


### PR DESCRIPTION
This PR fixes parsing error for Granite 3.2 where citation text in model output contains a colon. For example:
```
<co>1</co> Document 2: "3f : foo bar"
```
It also adds some resilience around citation parsing to handle improperly formatted or inconsistent citations and continue as best as possible, avoiding exceptions where possible.

Fixes #117 