### PR TITLE
ci: free disk space in more workflows before install python

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,6 +60,9 @@ jobs:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
 
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
       - name: Setup Python 3.11
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:

--- a/.github/workflows/test_contrib.yml
+++ b/.github/workflows/test_contrib.yml
@@ -58,6 +58,9 @@ jobs:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
 
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -56,6 +56,9 @@ jobs:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
 
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -56,6 +56,9 @@ jobs:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
 
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:


### PR DESCRIPTION
* CI is currently failing with out of disk when running examples. Trying to use free-disk-space consistently.