### PR TITLE
Re-add LocalVLLMServer and enable VCR

### DIFF
--- a/notebooks/certainty.ipynb
+++ b/notebooks/certainty.ipynb
@@ -11,20 +11,10 @@
     "    https://huggingface.co/ibm-granite/granite-uncertainty-3.2-8b-lora\n",
     ")\n",
     "\n",
-    "To run this notebook, you will need to host Granite 3.2 8B and the Granite 3.2 8B \n",
-    "Instruct Uncertainty LoRA on your own machine. The constants below assume you started a\n",
-    "local vLLM server with the command:\n",
-    "```\n",
-    "vllm serve ibm-granite/granite-3.2-8b-instruct \\\n",
-    "    --enable-lora \\\n",
-    "    --max_lora_rank 64 \\\n",
-    "    --lora-modules ibm-granite/granite-uncertainty-3.2-8b-lora=ibm-granite/granite-uncertainty-3.2-8b-lora \\\n",
-    "    --port 11434 \\\n",
-    "    --gpu-memory-utilization 0.5 \\\n",
-    "    --max-model-len 8192\n",
-    "```\n",
-    "\n",
-    "Update the constants below to reflecthow you are hosting the model."
+    "This notebook can run its own vLLM server to perform inference, or you can host the \n",
+    "models on your own server. To use your own server, set the `run_server` variable below\n",
+    "to `False` and set appropriate values for the constants \n",
+    "`openai_base_url`, `openai_base_model_name` and `openai_lora_model_name`."
    ]
   },
   {
@@ -38,6 +28,7 @@
     "    Granite3Point2Inputs,\n",
     ")\n",
     "from granite_io import make_io_processor, make_backend\n",
+    "from granite_io.backend.vllm_server import LocalVLLMServer\n",
     "from granite_io.io.certainty import CertaintyIOProcessor, CertaintyCompositeIOProcessor"
    ]
   },
@@ -51,11 +42,7 @@
     "base_model_name = \"ibm-granite/granite-3.2-8b-instruct\"\n",
     "lora_model_name = \"ibm-granite/granite-uncertainty-3.2-8b-lora\"\n",
     "\n",
-    "# You will need to set the following variables to appropriate values for your own\n",
-    "# OpenAI-compatible inference server:\n",
-    "openai_base_url = \"http://localhost:11434/v1\"\n",
-    "openai_base_model_name = \"ibm-granite/granite-3.2-8b-instruct\"\n",
-    "openai_lora_model_name = \"ibm-granite/granite-uncertainty-3.2-8b-lora\""
+    "run_server = True"
    ]
   },
   {
@@ -64,20 +51,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "backend = make_backend(\n",
-    "    \"openai\",\n",
-    "    {\n",
-    "        \"model_name\": openai_base_model_name,\n",
-    "        \"openai_base_url\": openai_base_url,\n",
-    "    },\n",
-    ")\n",
-    "lora_backend = make_backend(\n",
-    "    \"openai\",\n",
-    "    {\n",
-    "        \"model_name\": openai_lora_model_name,\n",
-    "        \"openai_base_url\": openai_base_url,\n",
-    "    },\n",
-    ")"
+    "if run_server:\n",
+    "    # Start by firing up a local vLLM server and connecting a backend instance to it.\n",
+    "    server = LocalVLLMServer(\n",
+    "        base_model_name, lora_adapters=[(lora_model_name, lora_model_name)]\n",
+    "    )\n",
+    "    server.wait_for_startup(200)\n",
+    "    lora_backend = server.make_lora_backend(lora_model_name)\n",
+    "    backend = server.make_backend()\n",
+    "else:  # if not run_server\n",
+    "    # Use an existing server.\n",
+    "    # Modify the constants here as needed.\n",
+    "    openai_base_url = \"http://localhost:55555/v1\"\n",
+    "    openai_api_key = \"granite_intrinsics_1234\"\n",
+    "    openai_base_model_name = base_model_name\n",
+    "    openai_lora_model_name = lora_model_name\n",
+    "    backend = make_backend(\n",
+    "        \"openai\",\n",
+    "        {\n",
+    "            \"model_name\": openai_base_model_name,\n",
+    "            \"openai_base_url\": openai_base_url,\n",
+    "            \"openai_api_key\": openai_api_key,\n",
+    "        },\n",
+    "    )\n",
+    "    lora_backend = make_backend(\n",
+    "        \"openai\",\n",
+    "        {\n",
+    "            \"model_name\": openai_lora_model_name,\n",
+    "            \"openai_base_url\": openai_base_url,\n",
+    "            \"openai_api_key\": openai_api_key,\n",
+    "        },\n",
+    "    )"
    ]
   },
   {
@@ -219,6 +223,17 @@
     "    chat_input.with_addl_generate_params({\"n\": 5, \"temperature\": 1.0})\n",
     ")\n",
     "composite_results_2.results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Free up GPU resources\n",
+    "if \"server\" in locals():\n",
+    "    server.shutdown()"
    ]
   },
   {

--- a/src/granite_io/backend/__init__.py
+++ b/src/granite_io/backend/__init__.py
@@ -11,3 +11,4 @@ from granite_io.backend.registry import backend, make_backend  # noqa: F401
 import granite_io.backend.litellm  # noqa: F401
 import granite_io.backend.openai  # noqa: F401
 import granite_io.backend.transformers  # noqa: F401
+import granite_io.backend.vllm_server  # noqa: F401

--- a/src/granite_io/backend/vllm_server.py
+++ b/src/granite_io/backend/vllm_server.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Note: Never rename this file to "vllm.py". You will have a bad time.
+
+# Standard
+from collections.abc import Iterable
+import asyncio
+import logging
+import os
+import shutil
+import signal
+import socketserver
+import subprocess
+import sys
+import time
+import urllib
+import uuid
+
+# Third Party
+import aconfig
+import aiohttp
+
+# Local
+from granite_io.backend.openai import OpenAIBackend
+
+# Perform the "set sensible defaults for Python logging" ritual.
+logger = logging.getLogger("granite_io.backend.vllm_server")
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler(stream=sys.stdout)
+handler.setFormatter(
+    logging.Formatter("%(levelname)s %(asctime)s %(message)s", datefmt="%H:%M:%S")
+)
+logger.addHandler(handler)
+
+
+class LocalVLLMServer:
+    """
+    Class that manages a vLLM server subprocess on the local machine.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        device_name: str = "auto",
+        served_model_name: str | None = None,
+        api_key: str | None = None,
+        port: int | None = None,
+        gpu_memory_utilization: float = 0.45,
+        max_model_len: int = 32768,
+        enforce_eager: bool = True,
+        log_level: str = "INFO",
+        lora_adapters: Iterable[tuple[str, str]] = tuple(),
+        max_lora_rank: int = 64,
+    ):
+        """
+        :param model_name: Path to local file or Hugging Face coordinates of model
+        :param served_model_name: Optional alias under which the model should be named
+         in the OpenAI API
+        :param device_name: Name of vLLM device to use for inference. Current options
+         are {auto,cuda,neuron,cpu,tpu,xpu,hpu}.
+         Note that the "cpu" option requires building vLLM from source.
+        :param api_key: Optional API key for the server to require. Otherwise this class
+         will generate a random key.
+        :param port: Optional port on localhost to use. If not specified, this class
+         will pick a random unused port.
+        :param gpu_memory_utilization: What fraction of the GPU's memory to dedicate
+         to the target model
+        :param max_model_len: Maximum context length to use before truncating to avoid
+         running out of GPU memory.
+        :param enforce_eager: If ``True`` skip compilation to make the server start up
+         faster.
+        :param log_level: Logging level for the vLLM subprocess
+        :param lora_adapters: Map from model name to LoRA adapter location
+        :param max_lora_rank: vLLM needs you to specify an upper bound on the size of
+         the shared dimension of the low-rank approximations in LoRA adapters.
+        """
+        self._model_name = model_name
+        self._served_model_name = served_model_name
+        self._lora_adapters = lora_adapters
+        self._lora_names = [t[0] for t in lora_adapters]
+
+        vllm_exec = shutil.which("vllm")
+        if vllm_exec is None:
+            raise ValueError("vLLM not installed.")
+
+        if not port:
+            # Find an open port on localhost
+            with socketserver.TCPServer(("localhost", 0), None) as s:
+                port = s.server_address[1]
+        self._server_port = port
+
+        # Generate shared secret so that other local processes can't hijack our server.
+        self._api_key = api_key if api_key else str(uuid.uuid4())
+
+        environment = os.environ.copy()
+        # Disable annoying log messages about current throughput being zero
+        # Unfortunately the only documented way to do this is to turn off all
+        # logging.
+        # TODO: Look for undocumented solutions.
+        environment["VLLM_LOGGING_LEVEL"] = log_level
+        environment["VLLM_API_KEY"] = self._api_key
+
+        # Immediately start up a server process on the open port
+        command_parts = [
+            vllm_exec,
+            "serve",
+            model_name,
+            "--port",
+            str(self._server_port),
+            "--gpu-memory-utilization",
+            str(gpu_memory_utilization),
+            "--max-model-len",
+            str(max_model_len),
+            "--guided_decoding_backend",
+            "outlines",
+            "--device",
+            device_name,
+        ]
+        if enforce_eager:
+            command_parts.append("--enforce-eager")
+        if served_model_name is not None:
+            command_parts.append("--served-model-name")
+            command_parts.append(served_model_name)
+        if len(lora_adapters) > 0:
+            command_parts.append("--enable-lora")
+            command_parts.append("--max_lora_rank")
+            command_parts.append(str(max_lora_rank))
+            command_parts.append("--lora-modules")
+            for k, v in lora_adapters:
+                command_parts.append(f"{k}={v}")
+
+        logger.info("Running: %s", " ".join(command_parts))  # pylint: disable=logging-not-lazy
+        self._subproc = subprocess.Popen(command_parts, env=environment)  # pylint: disable=consider-using-with
+
+    def __repr__(self):
+        return f"LocalVLLMServer({self._model_name} -> {self._base_url()})"
+
+    def _base_url(self):
+        return f"http://localhost:{self._server_port}"
+
+    @property
+    def openai_url(self) -> str:
+        return f"{self._base_url()}/v1"
+
+    @property
+    def openai_api_key(self) -> str:
+        return self._api_key
+
+    def wait_for_startup(self, timeout_sec: float | None = None):
+        """
+        Blocks  until the server has started.
+        :param timeout_sec: Optional upper limit for how long to block. If this
+         limit is reached, this method will raise a TimeoutError
+        """
+        start_sec = time.time()
+        while timeout_sec is None or time.time() - start_sec < timeout_sec:
+            try:  # Exceptions as control flow due to library design
+                with urllib.request.urlopen(self._base_url() + "/ping") as response:
+                    _ = response.read().decode("utf-8")
+                return  # Success
+            except urllib.error.URLError:
+                time.sleep(1)
+        raise TimeoutError(
+            f"Failed to connect to {self._base_url()} after {timeout_sec} seconds."
+        )
+
+    async def await_for_startup(self, timeout_sec: float | None = None):
+        """
+        Blocks the local coroutine until the server has started.
+        :param timeout_sec: Optional upper limit for how long to block. If this
+         limit is reached, this method will raise a TimeoutError
+        """
+        start_sec = time.time()
+        while timeout_sec is None or time.time() - start_sec < timeout_sec:
+            try:  # Exceptions as control flow due to aiohttp library design
+                async with (
+                    aiohttp.ClientSession() as session,
+                    session.get(self._base_url() + "/ping") as resp,
+                ):
+                    await resp.text()
+                return  # Success
+            except (ConnectionRefusedError, aiohttp.ClientConnectorError):
+                await asyncio.sleep(1)
+        raise TimeoutError(
+            f"Failed to connect to {self._base_url()} after {timeout_sec} seconds."
+        )
+
+    def shutdown(self):
+        # Sending SIGINT to the vLLM process seems to be the only way to stop it.
+        # DO NOT USE SIGKILL!!!
+        self._subproc.send_signal(signal.SIGINT)
+
+    def make_backend(self) -> OpenAIBackend:
+        """
+        :returns: A backend instance pointed at the primary model that our subprocess
+         is serving.
+        """
+        return OpenAIBackend(
+            aconfig.Config(
+                {
+                    "model_name": (
+                        self._served_model_name
+                        if self._served_model_name
+                        else self._model_name
+                    ),
+                    "openai_base_url": f"{self._base_url()}/v1",
+                    "openai_api_key": self._api_key,
+                }
+            )
+        )
+
+    def make_lora_backend(self, lora_name: str) -> OpenAIBackend:
+        """
+        :param lora_name: Name of one of the LoRA adapters that was passed to the
+        constructor of this object.
+
+        :returns: A backend instance pointed at the specified LoRA adapter.
+        """
+        if lora_name not in self._lora_names:
+            raise ValueError(
+                f"Unexpected LoRA adapter name {lora_name}. Known names "
+                f"are: {self._lora_names}"
+            )
+        return OpenAIBackend(
+            aconfig.Config(
+                {
+                    "model_name": lora_name,
+                    "openai_base_url": f"{self._base_url()}/v1",
+                    "openai_api_key": self._api_key,
+                }
+            )
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,31 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from collections.abc import Iterable
-import asyncio
 import collections.abc
-import logging
-import os
-import shutil
-import signal
-import socketserver
-import subprocess
-import sys
-import time
-import urllib.request
-import uuid
 
 # Third Party
-import aconfig
-import aiohttp
 import pytest
 import torch
 
 # Local
 from granite_io import make_backend
 from granite_io.backend import Backend
-from granite_io.backend.openai import OpenAIBackend
+from granite_io.backend.vllm_server import LocalVLLMServer
 from granite_io.io.consts import _GRANITE_3_2_2B_HF
+from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor import (
+    override_date_for_testing as g32_override_date_for_testing,
+)
 
 
 @pytest.fixture(scope="session")
@@ -62,6 +51,24 @@ def backend_transformers() -> Backend:
     )
 
 
+@pytest.fixture(scope="function")
+def fake_date():
+    """
+    We need today's date to be constant so that ``vcrpy`` functions on our prompts.
+
+    By wrapping the creation of this date in a fixture, we can be sure to reset to
+    normal behavior if a test fails.
+
+    :returns: a fake version of today's date, for use in prompt text that mentions the
+     date.
+    """
+    yield "April 1, 2025"
+
+    # Cleanup code. Augment as needed as we add new IO processors with date-dependent
+    # prompts.
+    g32_override_date_for_testing(None)
+
+
 @pytest.fixture(
     scope="session", params=[backend_openai, backend_litellm, backend_transformers]
 )
@@ -69,219 +76,14 @@ def backend_x(request) -> Backend:
     return request.param()
 
 
-# Perform the "set sensible defaults for Python logging" ritual.
-logger = logging.getLogger("granite_io.backend.vllm_server")
-logger.setLevel(logging.INFO)
-handler = logging.StreamHandler(stream=sys.stdout)
-handler.setFormatter(
-    logging.Formatter("%(levelname)s %(asctime)s %(message)s", datefmt="%H:%M:%S")
-)
-logger.addHandler(handler)
-
-
-class LocalVLLMServer:
-    """
-    Class that manages a vLLM server subprocess on the local machine.
-    """
-
-    def __init__(
-        self,
-        model_name: str,
-        device_name: str = "auto",
-        served_model_name: str | None = None,
-        api_key: str | None = None,
-        port: int | None = None,
-        gpu_memory_utilization: float = 0.45,
-        max_model_len: int = 32768,
-        enforce_eager: bool = True,
-        log_level: str = "INFO",
-        lora_adapters: Iterable[tuple[str, str]] = tuple(),
-        max_lora_rank: int = 64,
-    ):
-        """
-        :param model_name: Path to local file or Hugging Face coordinates of model
-        :param served_model_name: Optional alias under which the model should be named
-         in the OpenAI API
-        :param device_name: Name of vLLM device to use for inference. Current options
-         are {auto,cuda,neuron,cpu,tpu,xpu,hpu}.
-         Note that the "cpu" option requires building vLLM from source.
-        :param api_key: Optional API key for the server to require. Otherwise this class
-         will generate a random key.
-        :param port: Optional port on localhost to use. If not specified, this class
-         will pick a random unused port.
-        :param gpu_memory_utilization: What fraction of the GPU's memory to dedicate
-         to the target model
-        :param max_model_len: Maximum context length to use before truncating to avoid
-         running out of GPU memory.
-        :param enforce_eager: If ``True`` skip compilation to make the server start up
-         faster.
-        :param log_level: Logging level for the vLLM subprocess
-        :param lora_adapters: Map from model name to LoRA adapter location
-        :param max_lora_rank: vLLM needs you to specify an upper bound on the size of
-         the shared dimension of the low-rank approximations in LoRA adapters.
-        """
-        self._model_name = model_name
-        self._served_model_name = served_model_name
-        self._lora_adapters = lora_adapters
-        self._lora_names = [t[0] for t in lora_adapters]
-
-        vllm_exec = shutil.which("vllm")
-        if vllm_exec is None:
-            raise ValueError("vLLM not installed.")
-
-        if not port:
-            # Find an open port on localhost
-            with socketserver.TCPServer(("localhost", 0), None) as s:
-                port = s.server_address[1]
-        self._server_port = port
-
-        # Generate shared secret so that other local processes can't hijack our server.
-        self._api_key = api_key if api_key else str(uuid.uuid4())
-
-        environment = os.environ.copy()
-        # Disable annoying log messages about current throughput being zero
-        # Unfortunately the only documented way to do this is to turn off all
-        # logging.
-        # TODO: Look for undocumented solutions.
-        environment["VLLM_LOGGING_LEVEL"] = log_level
-        environment["VLLM_API_KEY"] = self._api_key
-
-        # Immediately start up a server process on the open port
-        command_parts = [
-            vllm_exec,
-            "serve",
-            model_name,
-            "--port",
-            str(self._server_port),
-            "--gpu-memory-utilization",
-            str(gpu_memory_utilization),
-            "--max-model-len",
-            str(max_model_len),
-            "--guided_decoding_backend",
-            "outlines",
-            "--device",
-            device_name,
-        ]
-        if enforce_eager:
-            command_parts.append("--enforce-eager")
-        if served_model_name is not None:
-            command_parts.append("--served-model-name")
-            command_parts.append(served_model_name)
-        if len(lora_adapters) > 0:
-            command_parts.append("--enable-lora")
-            command_parts.append("--max_lora_rank")
-            command_parts.append(str(max_lora_rank))
-            command_parts.append("--lora-modules")
-            for k, v in lora_adapters:
-                command_parts.append(f"{k}={v}")
-
-        logger.info("Running: %s", " ".join(command_parts))  # pylint: disable=logging-not-lazy
-        self._subproc = subprocess.Popen(command_parts, env=environment)  # pylint: disable=consider-using-with
-
-    def __repr__(self):
-        return f"LocalVLLMServer({self._model_name} -> {self._base_url()})"
-
-    def _base_url(self):
-        return f"http://localhost:{self._server_port}"
-
-    @property
-    def openai_url(self) -> str:
-        return f"{self._base_url()}/v1"
-
-    @property
-    def openai_api_key(self) -> str:
-        return self._api_key
-
-    def wait_for_startup(self, timeout_sec: float | None = None):
-        """
-        Blocks  until the server has started.
-        :param timeout_sec: Optional upper limit for how long to block. If this
-         limit is reached, this method will raise a TimeoutError
-        """
-        start_sec = time.time()
-        while timeout_sec is None or time.time() - start_sec < timeout_sec:
-            try:  # Exceptions as control flow due to library design
-                with urllib.request.urlopen(self._base_url() + "/ping") as response:
-                    _ = response.read().decode("utf-8")
-                return  # Success
-            except urllib.error.URLError:
-                time.sleep(1)
-        raise TimeoutError(
-            f"Failed to connect to {self._base_url()} after {timeout_sec} seconds."
-        )
-
-    async def await_for_startup(self, timeout_sec: float | None = None):
-        """
-        Blocks the local coroutine until the server has started.
-        :param timeout_sec: Optional upper limit for how long to block. If this
-         limit is reached, this method will raise a TimeoutError
-        """
-        start_sec = time.time()
-        while timeout_sec is None or time.time() - start_sec < timeout_sec:
-            try:  # Exceptions as control flow due to aiohttp library design
-                async with (
-                    aiohttp.ClientSession() as session,
-                    session.get(self._base_url() + "/ping") as resp,
-                ):
-                    await resp.text()
-                return  # Success
-            except (ConnectionRefusedError, aiohttp.ClientConnectorError):
-                await asyncio.sleep(1)
-        raise TimeoutError(
-            f"Failed to connect to {self._base_url()} after {timeout_sec} seconds."
-        )
-
-    def shutdown(self):
-        # Sending SIGINT to the vLLM process seems to be the only way to stop it.
-        # DO NOT USE SIGKILL!!!
-        self._subproc.send_signal(signal.SIGINT)
-
-    def make_backend(self) -> OpenAIBackend:
-        """
-        :returns: A backend instance pointed at the primary model that our subprocess
-         is serving.
-        """
-        return OpenAIBackend(
-            aconfig.Config(
-                {
-                    "model_name": (
-                        self._served_model_name
-                        if self._served_model_name
-                        else self._model_name
-                    ),
-                    "openai_base_url": f"{self._base_url()}/v1",
-                    "openai_api_key": self._api_key,
-                }
-            )
-        )
-
-    def make_lora_backend(self, lora_name: str) -> OpenAIBackend:
-        """
-        :param lora_name: Name of one of the LoRA adapters that was passed to the
-        constructor of this object.
-
-        :returns: A backend instance pointed at the specified LoRA adapter.
-        """
-        if lora_name not in self._lora_names:
-            raise ValueError(
-                f"Unexpected LoRA adapter name {lora_name}. Known names "
-                f"are: {self._lora_names}"
-            )
-        return OpenAIBackend(
-            aconfig.Config(
-                {
-                    "model_name": lora_name,
-                    "openai_base_url": f"{self._base_url()}/v1",
-                    "openai_api_key": self._api_key,
-                }
-            )
-        )
-
-
 @pytest.fixture(scope="session")
 def lora_server() -> collections.abc.Generator[LocalVLLMServer, object, None]:
     """
+    Fixture that runs a local vLLM server. The server uses a fixed port because the
+    ``vcrpy`` package requires fixed local ports.
+
     :returns: vLLM server with all the LoRAs for which we currently have IO processors
+
     """
     if not torch.cuda.is_available():
         pytest.xfail("GPU required to run vLLM. vLLM required to run model.")
@@ -293,7 +95,7 @@ def lora_server() -> collections.abc.Generator[LocalVLLMServer, object, None]:
         ("certainty", "ibm-granite/granite-uncertainty-3.2-8b-lora"),
     ]
 
-    server = LocalVLLMServer(base_model, lora_adapters=lora_adapters)
+    server = LocalVLLMServer(base_model, lora_adapters=lora_adapters, port=35782)
     server.wait_for_startup(200)
     yield server
 

--- a/tests/io/cassettes/test_certainty/test_run_composite.yaml
+++ b/tests/io/cassettes/test_certainty/test_run_composite.yaml
@@ -1,0 +1,718 @@
+interactions:
+- request:
+    body: '{"model":"ibm-granite/granite-3.2-8b-instruct","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>","best_of":5,"n":5,"temperature":0.2}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '852'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-c6fb0dc369614404b9f36c349e7c0749","object":"text_completion","created":1744400551,"model":"ibm-granite/granite-3.2-8b-instruct","choices":[{"index":0,"text":"Based
+      on the provided documents, only your dog has fleas.","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null},{"index":1,"text":"Based
+      on the provided documents, only your dog has fleas.","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null},{"index":2,"text":"According
+      to the information I have, only your dog has fleas.","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null},{"index":3,"text":"Based
+      on the provided documents, only your dog has fleas. The document","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null},{"index":4,"text":"Based
+      on the provided documents, only your dog has fleas. The document","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":152,"total_tokens":230,"completion_tokens":78,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '1089'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:30 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Based
+      on the provided documents, only your dog has fleas.<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","n":1,"temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '987'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-8ea7c141ba3e4ba8bdb0476f34379b28","object":"text_completion","created":1744400553,"model":"certainty","choices":[{"index":0,"text":"8","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":172,"total_tokens":174,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:32 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Based
+      on the provided documents, only your dog has fleas.<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","n":1,"temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '987'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-76f28aeb60724e828c835142bcb86d4a","object":"text_completion","created":1744400559,"model":"certainty","choices":[{"index":0,"text":"8","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":172,"total_tokens":174,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:38 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>According
+      to the information I have, only your dog has fleas.<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","n":1,"temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '991'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-f8abef75f70546169597394c7acbe89e","object":"text_completion","created":1744400559,"model":"certainty","choices":[{"index":0,"text":"8","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":174,"total_tokens":176,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:38 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Based
+      on the provided documents, only your dog has fleas. The document<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","n":1,"temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1000'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-77be1d6604c14fa0b4283ff8fa2af9fe","object":"text_completion","created":1744400559,"model":"certainty","choices":[{"index":0,"text":"8","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":174,"total_tokens":176,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:38 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Based
+      on the provided documents, only your dog has fleas. The document<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","n":1,"temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1000'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-6daf09198c724f35b2998d747ced18ef","object":"text_completion","created":1744400560,"model":"certainty","choices":[{"index":0,"text":"8","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":174,"total_tokens":176,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:39 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"ibm-granite/granite-3.2-8b-instruct","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>","best_of":5,"n":5,"temperature":0.2}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '852'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-abecc0272d624c4eba5b29847b33377b","object":"text_completion","created":1744400560,"model":"ibm-granite/granite-3.2-8b-instruct","choices":[{"index":0,"text":"Based
+      on the provided documents, only your dog has fleas. The document","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null},{"index":1,"text":"Based
+      on the provided documents, your dog has fleas. There is no","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null},{"index":2,"text":"Based
+      on the provided documents, only your dog has fleas.","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null},{"index":3,"text":"Based
+      on the provided documents, only your dog has fleas. Your cat","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null},{"index":4,"text":"Based
+      on the provided documents, only your dog has fleas. The document","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":152,"total_tokens":231,"completion_tokens":79,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '1103'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:40 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Based
+      on the provided documents, only your dog has fleas. The document<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","n":1,"temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1000'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-7fd3df4237b3442b93de9df04a25ead6","object":"text_completion","created":1744400563,"model":"certainty","choices":[{"index":0,"text":"8","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":174,"total_tokens":176,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:42 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Based
+      on the provided documents, your dog has fleas. There is no<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","n":1,"temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '994'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-ed46b30fc0bd4d5fb0fe30c9ffef272b","object":"text_completion","created":1744400563,"model":"certainty","choices":[{"index":0,"text":"7","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":174,"total_tokens":176,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:42 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Based
+      on the provided documents, only your dog has fleas.<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","n":1,"temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '987'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-7ed4f8828430487c9897452cf63ad01d","object":"text_completion","created":1744400563,"model":"certainty","choices":[{"index":0,"text":"8","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":172,"total_tokens":174,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:42 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Based
+      on the provided documents, only your dog has fleas. Your cat<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","n":1,"temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '996'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-5596a6c13e4c4751a49ddcb03642dfc1","object":"text_completion","created":1744400564,"model":"certainty","choices":[{"index":0,"text":"8","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":174,"total_tokens":176,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:43 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Based
+      on the provided documents, only your dog has fleas. The document<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","n":1,"temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1000'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-107ce14b14144c90ae32148505bef1b6","object":"text_completion","created":1744400564,"model":"certainty","choices":[{"index":0,"text":"8","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":174,"total_tokens":176,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:42:43 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/io/cassettes/test_certainty/test_run_model.yaml
+++ b/tests/io/cassettes/test_certainty/test_run_model.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: '{"model":"certainty","prompt":"<|start_of_role|>system<|end_of_role|>Knowledge
+      Cutoff Date: April 2024.\nToday''s Date: April 1, 2025.\nYou are Granite, developed
+      by IBM.Write the response to the user''s input by strictly aligning with the
+      facts in the provided documents. If the information needed to answer the question
+      is not available in the documents, inform the user that the question cannot
+      be answered based on the available data.<|end_of_text|>\n<|start_of_role|>documents<|end_of_role|>Document
+      0\nMy dog has fleas.\n\nDocument 1\nMy cat does not have fleas.<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Welcome
+      to pet questions!<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>Which
+      of my pets have fleas?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>Only
+      your dog has fleas.<|end_of_text|>\n<|start_of_role|>certainty<|end_of_role|>","temperature":0.0,"guided_choice":["0","1","2","3","4","5","6","7","8","9"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '948'
+      content-type:
+      - application/json
+      host:
+      - localhost:35782
+      user-agent:
+      - AsyncOpenAI/Python 1.66.5
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.66.5
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.11
+    method: POST
+    uri: http://localhost:35782/v1/completions
+  response:
+    content: '{"id":"cmpl-558c17c5a4da4262b970f62715674477","object":"text_completion","created":1744400375,"model":"certainty","choices":[{"index":0,"text":"8","logprobs":null,"finish_reason":"stop","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":166,"total_tokens":168,"completion_tokens":2,"prompt_tokens_details":null}}'
+    headers:
+      content-length:
+      - '330'
+      content-type:
+      - application/json
+      date:
+      - Fri, 11 Apr 2025 19:39:34 GMT
+      server:
+      - uvicorn
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1


### PR DESCRIPTION
This PR makes following changes:

* Makes the `LocalVLLMServer` class part of the library
* Enables VCR for the tests of the certainty intrinsic
* Makes the notebook for the certainty intrinsic run its own captive server to serve the LoRA adapter