### PR TITLE
feat: Adds a "select_parts" kwarg to input transform calls

### DIFF
--- a/src/granite_io/io/granite_3_2/granite_3_2.py
+++ b/src/granite_io/io/granite_3_2/granite_3_2.py
@@ -2,7 +2,6 @@
 
 # Third Party
 import aconfig
-from typing import Set
 
 # Local
 from granite_io.backend.base import Backend
@@ -14,7 +13,6 @@ from granite_io.io.consts import (
 )
 from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor import (
     Granite3Point2InputProcessor,
-    PromptPartSelection,
 )
 from granite_io.io.granite_3_2.output_processors.granite_3_2_output_processor import (
     Granite3Point2OutputProcessor,
@@ -58,10 +56,9 @@ class Granite3Point2InputOutputProcessor(ModelDirectInputOutputProcessor):
         self,
         inputs: ChatCompletionInputs,
         add_generation_prompt: bool = True,
-        select_parts: Set[PromptPartSelection] = None,
     ) -> str:
         input_processor = Granite3Point2InputProcessor()
-        return input_processor.transform(inputs, add_generation_prompt, select_parts)
+        return input_processor.transform(inputs, add_generation_prompt)
 
     def output_to_result(
         self,

--- a/src/granite_io/io/granite_3_2/granite_3_2.py
+++ b/src/granite_io/io/granite_3_2/granite_3_2.py
@@ -2,6 +2,7 @@
 
 # Third Party
 import aconfig
+from typing import Set
 
 # Local
 from granite_io.backend.base import Backend
@@ -13,6 +14,7 @@ from granite_io.io.consts import (
 )
 from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor import (
     Granite3Point2InputProcessor,
+    PromptPartSelection
 )
 from granite_io.io.granite_3_2.output_processors.granite_3_2_output_processor import (
     Granite3Point2OutputProcessor,
@@ -53,10 +55,11 @@ class Granite3Point2InputOutputProcessor(ModelDirectInputOutputProcessor):
         super().__init__(backend=backend)
 
     def inputs_to_string(
-        self, inputs: ChatCompletionInputs, add_generation_prompt: bool = True
+        self, inputs: ChatCompletionInputs, add_generation_prompt: bool = True,
+        select_parts: Set[PromptPartSelection] = None
     ) -> str:
         input_processor = Granite3Point2InputProcessor()
-        return input_processor.transform(inputs, add_generation_prompt)
+        return input_processor.transform(inputs, add_generation_prompt, select_parts)
 
     def output_to_result(
         self,

--- a/src/granite_io/io/granite_3_2/granite_3_2.py
+++ b/src/granite_io/io/granite_3_2/granite_3_2.py
@@ -14,7 +14,7 @@ from granite_io.io.consts import (
 )
 from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor import (
     Granite3Point2InputProcessor,
-    PromptPartSelection
+    PromptPartSelection,
 )
 from granite_io.io.granite_3_2.output_processors.granite_3_2_output_processor import (
     Granite3Point2OutputProcessor,
@@ -55,8 +55,10 @@ class Granite3Point2InputOutputProcessor(ModelDirectInputOutputProcessor):
         super().__init__(backend=backend)
 
     def inputs_to_string(
-        self, inputs: ChatCompletionInputs, add_generation_prompt: bool = True,
-        select_parts: Set[PromptPartSelection] = None
+        self,
+        inputs: ChatCompletionInputs,
+        add_generation_prompt: bool = True,
+        select_parts: Set[PromptPartSelection] = None,
     ) -> str:
         input_processor = Granite3Point2InputProcessor()
         return input_processor.transform(inputs, add_generation_prompt, select_parts)

--- a/src/granite_io/io/granite_3_2/input_processors/granite_3_2_input_processor.py
+++ b/src/granite_io/io/granite_3_2/input_processors/granite_3_2_input_processor.py
@@ -3,7 +3,6 @@
 # Standard
 import datetime
 import json
-from enum import Enum
 
 # Third Party
 from typing import Set
@@ -23,6 +22,7 @@ from granite_io.io.registry import input_processor
 from granite_io.types import (
     AssistantMessage,
     ChatCompletionInputs,
+    PromptPartSelection,
     SystemMessage,
     ToolResultMessage,
     UserMessage,
@@ -139,15 +139,6 @@ _DOCS_AND_HALLUCINATIONS_SYSTEM_MESSAGE_PART = """\
 Finally, after the response is written, include a numbered list of sentences from the \
 response that are potentially hallucinated and not based in the documents."""
 
-
-class PromptPartSelection(Enum):
-    """Enum for selecting which parts of the prompt to include in the final prompt
-    string."""
-    SYSTEM = "system"
-    TOOLS = "tools"
-    DOCUMENTS = "documents"
-    MESSAGES = "messages"
-    GENERATION_PROMPT = "generation_prompt"
 
 class Document(pydantic.BaseModel):
     text: str
@@ -601,11 +592,12 @@ class Granite3Point2InputProcessor(InputProcessor):
                 part if select_part else "" \
                 for select_part, part in inputs
             ])
-        else:
-            return (
-                system_message
-                + tools_part
-                + documents_part
-                + messages_part
-                + generation_prompt_part
-            )
+
+        # Return the full prompt string
+        return (
+            system_message
+            + tools_part
+            + documents_part
+            + messages_part
+            + generation_prompt_part
+        )

--- a/src/granite_io/io/granite_3_2/input_processors/granite_3_2_input_processor.py
+++ b/src/granite_io/io/granite_3_2/input_processors/granite_3_2_input_processor.py
@@ -493,7 +493,7 @@ class Granite3Point2InputProcessor(InputProcessor):
         self,
         inputs: ChatCompletionInputs,
         add_generation_prompt: bool = True,
-        select_parts: Set[PromptPartSelection] = None
+        select_parts: Set[PromptPartSelection] = None,
     ) -> str:
         # Downcast to a Granite-specific request type with possible additional fields.
         # This operation also performs additional validation.
@@ -581,17 +581,20 @@ class Granite3Point2InputProcessor(InputProcessor):
 
         if select_parts:
             # Filter the prompt parts based on the selected parts
-            inputs = [(PromptPartSelection.SYSTEM in select_parts, system_message),
-                      (PromptPartSelection.TOOLS in select_parts, tools_part),
-                      (PromptPartSelection.DOCUMENTS in select_parts, documents_part),
-                      (PromptPartSelection.MESSAGES in select_parts, messages_part),
-                      (PromptPartSelection.GENERATION_PROMPT in select_parts, \
-                        generation_prompt_part)]
-            
-            return "".join([
-                part if select_part else "" \
-                for select_part, part in inputs
-            ])
+            inputs = [
+                (PromptPartSelection.SYSTEM in select_parts, system_message),
+                (PromptPartSelection.TOOLS in select_parts, tools_part),
+                (PromptPartSelection.DOCUMENTS in select_parts, documents_part),
+                (PromptPartSelection.MESSAGES in select_parts, messages_part),
+                (
+                    PromptPartSelection.GENERATION_PROMPT in select_parts,
+                    generation_prompt_part,
+                ),
+            ]
+
+            return "".join(
+                [part if select_part else "" for select_part, part in inputs]
+            )
 
         # Return the full prompt string
         return (

--- a/src/granite_io/io/granite_3_2/input_processors/granite_3_2_input_processor.py
+++ b/src/granite_io/io/granite_3_2/input_processors/granite_3_2_input_processor.py
@@ -489,7 +489,7 @@ class Granite3Point2InputProcessor(InputProcessor):
             return None
         return result
 
-    def transform(
+    def selective_transform(
         self,
         inputs: ChatCompletionInputs,
         add_generation_prompt: bool = True,
@@ -603,4 +603,14 @@ class Granite3Point2InputProcessor(InputProcessor):
             + documents_part
             + messages_part
             + generation_prompt_part
+        )
+
+    def transform(
+        self,
+        inputs: ChatCompletionInputs,
+        add_generation_prompt: bool = True,
+    ) -> str:
+
+        return self.selective_transform(
+            inputs, add_generation_prompt=add_generation_prompt, select_parts=None
         )

--- a/src/granite_io/io/granite_3_3/granite_3_3.py
+++ b/src/granite_io/io/granite_3_3/granite_3_3.py
@@ -2,7 +2,6 @@
 
 # Third Party
 import aconfig
-from typing import Set
 
 # Local
 from granite_io.backend.base import Backend
@@ -26,7 +25,6 @@ from granite_io.types import (
     ChatCompletionResults,
     GenerateInputs,
     GenerateResults,
-    PromptPartSelection,
 )
 
 
@@ -85,10 +83,9 @@ class Granite3Point3InputOutputProcessor(ModelDirectInputOutputProcessor):
         self,
         inputs: ChatCompletionInputs,
         add_generation_prompt: bool = True,
-        select_parts: Set[PromptPartSelection] = None,
     ) -> str:
         input_processor = Granite3Point3InputProcessor()
-        return input_processor.transform(inputs, add_generation_prompt, select_parts)
+        return input_processor.transform(inputs, add_generation_prompt)
 
     def output_to_result(
         self,

--- a/src/granite_io/io/granite_3_3/granite_3_3.py
+++ b/src/granite_io/io/granite_3_3/granite_3_3.py
@@ -2,6 +2,7 @@
 
 # Third Party
 import aconfig
+from typing import Set
 
 # Local
 from granite_io.backend.base import Backend
@@ -25,6 +26,7 @@ from granite_io.types import (
     ChatCompletionResults,
     GenerateInputs,
     GenerateResults,
+    PromptPartSelection,
 )
 
 
@@ -80,10 +82,13 @@ class Granite3Point3InputOutputProcessor(ModelDirectInputOutputProcessor):
         return self.output_to_result(output=model_output, inputs=inputs)
 
     def inputs_to_string(
-        self, inputs: ChatCompletionInputs, add_generation_prompt: bool = True
+        self,
+        inputs: ChatCompletionInputs,
+        add_generation_prompt: bool = True,
+        select_parts: Set[PromptPartSelection] = None,
     ) -> str:
         input_processor = Granite3Point3InputProcessor()
-        return input_processor.transform(inputs, add_generation_prompt)
+        return input_processor.transform(inputs, add_generation_prompt, select_parts)
 
     def output_to_result(
         self,

--- a/src/granite_io/io/granite_3_3/input_processors/granite_3_3_input_processor.py
+++ b/src/granite_io/io/granite_3_3/input_processors/granite_3_3_input_processor.py
@@ -402,7 +402,7 @@ class Granite3Point3InputProcessor(InputProcessor):
             return None
         return result
 
-    def transform(
+    def selective_transform(
         self,
         inputs: ChatCompletionInputs,
         add_generation_prompt: bool = True,
@@ -511,4 +511,14 @@ class Granite3Point3InputProcessor(InputProcessor):
             + documents_part
             + messages_part
             + generation_prompt_part
+        )
+
+    def transform(
+        self,
+        inputs: ChatCompletionInputs,
+        add_generation_prompt: bool = True,
+    ) -> str:
+
+        return self.selective_transform(
+            inputs, add_generation_prompt=add_generation_prompt, select_parts=None
         )

--- a/src/granite_io/types.py
+++ b/src/granite_io/types.py
@@ -14,10 +14,10 @@ from typing_extensions import Literal, TypeAlias
 import pydantic
 
 
-
 class PromptPartSelection(Enum):
     """Enum for selecting which parts of the prompt to include in the final prompt
     string."""
+
     SYSTEM = "system"
     TOOLS = "tools"
     DOCUMENTS = "documents"

--- a/src/granite_io/types.py
+++ b/src/granite_io/types.py
@@ -6,11 +6,23 @@ Common shared types
 
 # Standard
 from collections.abc import Mapping
+from enum import Enum
 from typing import Any, List, Optional, Union
 
 # Third Party
 from typing_extensions import Literal, TypeAlias
 import pydantic
+
+
+
+class PromptPartSelection(Enum):
+    """Enum for selecting which parts of the prompt to include in the final prompt
+    string."""
+    SYSTEM = "system"
+    TOOLS = "tools"
+    DOCUMENTS = "documents"
+    MESSAGES = "messages"
+    GENERATION_PROMPT = "generation_prompt"
 
 
 class FunctionCall(pydantic.BaseModel):


### PR DESCRIPTION
`select_parts` allows only a portion of the chat template-transformed input to be produced. This is useful when the user wants to do manual prompt munging and wants to reproduce the portion of the template as Granite would prefer.

----

The goal is to support the ability to update apps like [`gpt_researcher`](https://github.com/assafelovic/gpt-researcher) to better support Granite. GPT researcher currently manually munges the prompt together with a `pretty_print_docs` function, and so it needs just the `documents` portion of the prompt.

I'm expecting this pattern may be common as we update other agents.

---
Sample code, based on the `io.ipynb` notebook:
```

# Third Party
import json
import aconfig

# Local
from granite_io.io.base import ChatCompletionInputs

from granite_io.io.granite_3_2.granite_3_2 import Granite3Point2InputOutputProcessor
from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor import PromptPartSelection

SAMPLE_INPUT_DOCS_TEST = {
    "messages": [
        {"role": "assistant", "content": ""}
    ],
    "tools" : [],
    "documents": [
        {"text": "I am a document"},
        {"text": "I am another document"}
    ],
    "thinking": "false"
}

input_json = SAMPLE_INPUT_DOCS_TEST
input_obj = ChatCompletionInputs.model_validate(input_json)

io_proc_str = Granite3Point2InputOutputProcessor().inputs_to_string(input_obj, select_parts={PromptPartSelection.DOCUMENTS})
print("####### IO PROC STR")
print(io_proc_str)
```

Expected output:
```
####### IO PROC STR
<|start_of_role|>documents<|end_of_role|>Document 0
I am a document

Document 1
I am another document<|end_of_text|>

```