### PR TITLE
Fix broken test case

### DIFF
--- a/tests/io/granite_3_2/input_processors/test_granite_3_2_input_processor.py
+++ b/tests/io/granite_3_2/input_processors/test_granite_3_2_input_processor.py
@@ -9,6 +9,9 @@ from granite_io.types import (
     ChatCompletionInputs,
     UserMessage,
 )
+from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor import (
+    override_date_for_testing,
+)
 from tests.test_utils import load_text_file
 
 _GENERALE_MODEL_NAME = "Granite 3.2"
@@ -21,6 +24,7 @@ def test_run_processor_reasoning():
         "Find the fastest way for a seller to visit all the cities in their region"
     )
     messages = [UserMessage(content=question)]
+    override_date_for_testing("May 02, 2025")
     prompt = input_processor.transform(
         ChatCompletionInputs(messages=messages, thinking=True)
     )
@@ -29,7 +33,7 @@ def test_run_processor_reasoning():
         os.path.join(_TEST_DATA_DIR, "test_reasoning_prompt.txt")
     )
     assert isinstance(prompt, str)
-    assert len(prompt) == len(expected_prompt)
+    assert prompt == expected_prompt
 
     # Prompt contains dates in first two lines of the text which change.
     # Therefore need to extract and test them separately first.

--- a/tests/io/granite_3_2/input_processors/test_granite_3_2_input_processor.py
+++ b/tests/io/granite_3_2/input_processors/test_granite_3_2_input_processor.py
@@ -5,12 +5,12 @@ import os
 
 # Local
 from granite_io import get_input_processor
+from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor import (
+    override_date_for_testing,
+)
 from granite_io.types import (
     ChatCompletionInputs,
     UserMessage,
-)
-from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor import (
-    override_date_for_testing,
 )
 from tests.test_utils import load_text_file
 

--- a/tests/io/granite_3_2/input_processors/test_granite_3_2_input_processor.py
+++ b/tests/io/granite_3_2/input_processors/test_granite_3_2_input_processor.py
@@ -5,14 +5,11 @@ import os
 
 # Local
 from granite_io import get_input_processor
-from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor import (
-    override_date_for_testing,
-)
 from granite_io.types import (
     ChatCompletionInputs,
     UserMessage,
 )
-from tests.test_utils import load_text_file
+from tests.test_utils import fix_granite_date, load_text_file
 
 _GENERALE_MODEL_NAME = "Granite 3.2"
 _TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
@@ -24,7 +21,6 @@ def test_run_processor_reasoning():
         "Find the fastest way for a seller to visit all the cities in their region"
     )
     messages = [UserMessage(content=question)]
-    override_date_for_testing("May 02, 2025")
     prompt = input_processor.transform(
         ChatCompletionInputs(messages=messages, thinking=True)
     )
@@ -33,17 +29,4 @@ def test_run_processor_reasoning():
         os.path.join(_TEST_DATA_DIR, "test_reasoning_prompt.txt")
     )
     assert isinstance(prompt, str)
-    assert prompt == expected_prompt
-
-    # Prompt contains dates in first two lines of the text which change.
-    # Therefore need to extract and test them separately first.
-    # Then we test the remaining text.
-    assert (
-        prompt.split("\n", 1)[0].split(":")[0]
-        == (expected_prompt.split("\n", 1)[0].split(":")[0])
-    )
-    assert (
-        prompt.split("\n", 1)[1].split(":")[0]
-        == (expected_prompt.split("\n", 1)[1].split(":")[0])
-    )
-    assert prompt.split("\n", 2)[-1] == expected_prompt.split("\n", 2)[-1]
+    assert prompt == fix_granite_date(expected_prompt)

--- a/tests/io/granite_3_3/input_processors/test_granite_3_3_input_processor.py
+++ b/tests/io/granite_3_3/input_processors/test_granite_3_3_input_processor.py
@@ -9,7 +9,7 @@ from granite_io.types import (
     ChatCompletionInputs,
     UserMessage,
 )
-from tests.test_utils import load_text_file
+from tests.test_utils import fix_granite_date, load_text_file
 
 _GENERALE_MODEL_NAME = "Granite 3.3"
 _TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
@@ -29,16 +29,4 @@ def test_run_processor_reasoning():
         os.path.join(_TEST_DATA_DIR, "test_reasoning_prompt.txt")
     )
     assert isinstance(prompt, str)
-
-    # Prompt contains dates in first two lines of the text which change.
-    # Therefore need to extract and test them separately first.
-    # Then we test the remaining text.
-    assert (
-        prompt.split("\n", 1)[0].split(":")[0]
-        == (expected_prompt.split("\n", 1)[0].split(":")[0])
-    )
-    assert (
-        prompt.split("\n", 1)[1].split(":")[0]
-        == (expected_prompt.split("\n", 1)[1].split(":")[0])
-    )
-    assert prompt.split("\n", 2)[-1] == expected_prompt.split("\n", 2)[-1]
+    assert prompt == fix_granite_date(expected_prompt)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,23 @@
 
 # Standard
 from pathlib import Path
+import datetime
+import re
 
 
 def load_text_file(file_name: str) -> str:
     text = Path(file_name).read_text(encoding="UTF-8")
     return text
+
+
+def fix_granite_date(prompt_with_wrong_date: str) -> str:
+    """
+    Replace the date string in a Granite prompt with today's date, in Granite prompts'
+    date format
+    """
+    date_str = datetime.datetime.now().strftime("%B %d, %Y")
+    return re.sub(
+        r"Today's Date: \w+ \d\d, \d\d\d\d\.",
+        f"Today's Date: {date_str}.",
+        prompt_with_wrong_date,
+    )


### PR DESCRIPTION
One of the test cases will only work if the current month's name is exactly 3 letters long. This change fixes that.