### PR TITLE
Don't add best_of when not already present

### DIFF
--- a/src/granite_io/backend/base.py
+++ b/src/granite_io/backend/base.py
@@ -68,14 +68,14 @@ class Backend(FactoryConstructible):
 
         # n (a.k.a. num_return_sequences) validation
         n = inputs_copy.n
+        best_of = inputs_copy.best_of
         if n is not None:  # noqa SIM102
             if n < 1:
                 raise ValueError(f"Invalid value for n ({n})")
-            if n > 1:
-                # best_of must be >= n
-                best_of = inputs_copy.best_of
-                if best_of is None or best_of < n:
-                    inputs_copy.best_of = n
+            if n > 1 and best_of is not None and best_of < n:
+                raise ValueError(
+                    f"best_of generation parameter must be >= n ({best_of=} and {n=})"
+                )
 
         # Some backends prefer an array to a string
         if isinstance(inputs_copy.stop, str):

--- a/src/granite_io/types.py
+++ b/src/granite_io/types.py
@@ -135,7 +135,8 @@ class GenerateInputs(pydantic.BaseModel):
         OPTIONAL PARAMS
             prompt: The prompt(s) to generate completions for.
             model: Model name or ID.
-            best_of: Generates best_of completions server-side.
+            best_of: Generates best_of completions server-side. **Deprecated** on most
+            platforms.
             echo: Echo back the prompt in addition to the completion.
             frequency_penalty: Penalize new tokens based on their existing frequency.
             logit_bias: Modify the likelihood of specified tokens.


### PR DESCRIPTION
The `best_of` parameter is deprecated in vLLM and OpenAI (and probably some other platforms). See https://github.com/vllm-project/vllm/issues/13361 for the vLLM deprecation notice.

Recent builds of vLLM will refuse to run model inference if the `best_of` parameter is present and the 0.1 backend is enabled.

Existing code in our library sets the `best_of` parameter on all requests where the `n` parameter is not set to 1. In addition to crashing vLLM, this parameter modification can alter the semantics of generation requests that make use of other parameters like `top_k` and `top_p` to control which top generation results are produced.

This change set modifies the logic in `Backend` such that the base class no longer adds `best_of` parameter values to requests that did not contain them.