### PR TITLE
Make nltk dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ To install from release ([PyPi package](https://pypi.org/project/granite-io/)):
 python3 -m venv granite_io_venv
 source granite_io_venv/bin/activate
 pip install granite-io
-python -m nltk.downloader punkt_tab
 ```
-> [!NOTE]
-> `granite-io` uses [NLTK Data](https://www.nltk.org/data.html) [Punkt Sentence Tokenizer](https://www.nltk.org/api/nltk.tokenize.punkt.html) for extracting contents when parsing output from a model. The command above shows how to install the required NLTK data. Check out [Installing NLTK Data](https://www.nltk.org/install.html#installing-nltk-data) for more detailed instructions.
 
 #### From Source
 
@@ -47,11 +44,7 @@ source granite_io_venv/bin/activate
 git clone https://github.com/ibm-granite/granite-io
 cd granite-io
 pip install -e .
-python -m nltk.downloader punkt_tab
 ```
-
-> [!NOTE]
-> `granite-io` uses [NLTK Data](https://www.nltk.org/data.html) [Punkt Sentence Tokenizer](https://www.nltk.org/api/nltk.tokenize.punkt.html) for extracting contents when parsing output from a model. The command above shows how to install the required NLTK data. Check out [Installing NLTK Data](https://www.nltk.org/install.html#installing-nltk-data) for more detailed instructions.
 
 ### Framework Example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dynamic = ["version"]
 dependencies = [
     "alchemy-config",
     "jsonschema",
-    "nltk~=3.9.1",
     "pydantic >= 2.0.0, < 3.0",  # LiteLLM requires >= 2
     "rouge_score",
     "aiohttp"
@@ -40,6 +39,9 @@ dependencies = [
 [project.optional-dependencies]
 transformers = [
     "transformers[torch]",
+]
+nltk = [
+    "nltk~=3.9.1",
 ]
 openai = [
     "openai >= 1.68.2, < 2.0",
@@ -76,6 +78,7 @@ dev = [
     "ipywidgets",
     "vcrpy==5.1.0",  # pin to avoid flakey newer
     "granite-io[transformers]",
+    "granite-io[nltk]",
     "granite-io[openai]",
     "granite-io[litellm]",
     "granite-io[voting]",

--- a/src/granite_io/io/citations/citations.py
+++ b/src/granite_io/io/citations/citations.py
@@ -7,9 +7,6 @@ I/O processor for the Granite citations intrinsic.
 # Standard
 import json
 
-# Third Party
-import nltk
-
 # Local
 from granite_io.backend.base import Backend
 from granite_io.io.base import (
@@ -22,6 +19,7 @@ from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor impo
     Granite3Point2InputProcessor,
     Granite3Point2Inputs,
 )
+from granite_io.optional import nltk_check
 from granite_io.types import (
     ChatCompletionInputs,
     ChatCompletionResult,
@@ -257,6 +255,9 @@ projects are visible to anyone.",
 
     def __init__(self, backend):
         super().__init__(backend=backend)
+        with nltk_check("the IBM LoRA Adapter for Citation Generation"):
+            # Third Party
+            import nltk
 
         # Input processor for the base model, which does most of the input formatting.
         self.base_input_processor = Granite3Point2InputProcessor()

--- a/src/granite_io/io/granite_3_2/output_processors/granite_3_2_output_parser.py
+++ b/src/granite_io/io/granite_3_2/output_processors/granite_3_2_output_parser.py
@@ -28,8 +28,8 @@ import logging
 import re
 import sys
 
-# Third Party
-from nltk import sent_tokenize  # pylint: disable=import-error
+# Local
+from granite_io.optional import nltk_check
 
 _CITATION_START = "# Citations:"
 _HALLUCINATION_START = "# Hallucinations:"
@@ -375,11 +375,14 @@ def _add_citation_response_spans(
         "response_begin": "The begin index of "response_text" within the response text"
         "response_end": "The end index of "response_text" within the response text"
     """
+    with nltk_check("Granite 3.2 citation support"):
+        # Third Party
+        import nltk
 
     augmented_citation_info = copy.deepcopy(citation_info)
 
     # Split response into sentences
-    response_sentences = sent_tokenize(response_text_with_citations)
+    response_sentences = nltk.sent_tokenize(response_text_with_citations)
 
     # Create dictionary of the response sentence (cleaned from citations) corresponding
     # to each citation ID

--- a/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
+++ b/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
@@ -29,9 +29,6 @@ import logging
 import re
 import sys
 
-# Third Party
-from nltk import sent_tokenize  # pylint: disable=import-error
-
 # Local
 from granite_io.io.consts import (
     _GRANITE_3_3_CITATIONS_START,
@@ -39,6 +36,7 @@ from granite_io.io.consts import (
     _GRANITE_3_3_CITE_START,
     _GRANITE_3_3_HALLUCINATIONS_START,
 )
+from granite_io.optional import nltk_check
 
 # Setup logger
 logger = logging.getLogger("granite_io.io.granite_3_3.output_parser")
@@ -364,11 +362,14 @@ def _add_citation_response_spans(
         "response_begin": "The begin index of "response_text" within the response text"
         "response_end": "The end index of "response_text" within the response text"
     """
+    with nltk_check("Granite 3.3 citation support"):
+        # Third Party
+        import nltk
 
     augmented_citation_info = copy.deepcopy(citation_info)
 
     # Split response into sentences
-    response_sentences = sent_tokenize(response_text_with_citations)
+    response_sentences = nltk.sent_tokenize(response_text_with_citations)
 
     # Create dictionary of the response sentence (cleaned from citations) corresponding
     # to each citation ID

--- a/src/granite_io/io/hallucinations/hallucinations.py
+++ b/src/granite_io/io/hallucinations/hallucinations.py
@@ -7,9 +7,6 @@ I/O processor for the Granite hallucinations intrinsic.
 # Standard
 import json
 
-# Third Party
-import nltk
-
 # Local
 from granite_io.backend.base import Backend
 from granite_io.io.base import (
@@ -21,6 +18,7 @@ from granite_io.io.granite_3_2.input_processors.granite_3_2_input_processor impo
     Granite3Point2InputProcessor,
     Granite3Point2Inputs,
 )
+from granite_io.optional import nltk_check
 from granite_io.types import (
     ChatCompletionInputs,
     ChatCompletionResult,
@@ -231,6 +229,9 @@ are visible to anyone.",
 
     def __init__(self, backend):
         super().__init__(backend=backend)
+        with nltk_check("LoRA Adapter for Hallucination Detection in RAG outputs"):
+            # Third Party
+            import nltk
 
         # Input processor for the base model, which does most of the input formatting.
         self.base_input_processor = Granite3Point2InputProcessor()

--- a/src/granite_io/io/retrieval/retrieval.py
+++ b/src/granite_io/io/retrieval/retrieval.py
@@ -7,12 +7,12 @@ import pathlib
 import shutil
 
 # Third Party
-import nltk
 import numpy as np
 import torch
 
 # Local
 from granite_io.io.base import ChatCompletionInputs, RequestProcessor
+from granite_io.optional import nltk_check
 from granite_io.types import Document
 
 
@@ -130,6 +130,10 @@ def compute_embeddings(
     # Third Party
     import pyarrow as pa
     import sentence_transformers
+
+    with nltk_check("generation of document embeddings"):
+        # Third Party
+        import nltk
 
     embedding_model = sentence_transformers.SentenceTransformer(embedding_model_name)
     sentence_splitter = nltk.tokenize.punkt.PunktSentenceTokenizer()

--- a/src/granite_io/optional.py
+++ b/src/granite_io/optional.py
@@ -8,6 +8,14 @@ Utilities for optional dependencies
 from contextlib import contextmanager
 import logging
 
+_NLTK_INSTALL_INSTRUCTIONS = """
+Please install nltk with:
+    pip install nltk
+In some environments you may also need to manually download model weights with:
+    python -m nltk.downloader punkt_tab
+See https://www.nltk.org/install.html#installing-nltk-data for more detailed 
+instructions."""
+
 
 @contextmanager
 def import_optional(extra_name: str):
@@ -22,3 +30,18 @@ def import_optional(extra_name: str):
             extra_name,
         )
         raise
+
+
+@contextmanager
+def nltk_check(feature_name: str):
+    """Variation on import_optional for nltk.
+
+    :param feature_name: Name of feature that requires NLTK"""
+    try:
+        yield
+    except ImportError as err:
+        raise ImportError(
+            f"'nltk' package not installed. This package is required for "
+            f"{feature_name} in the 'granite_io' library."
+            f"{_NLTK_INSTALL_INSTRUCTIONS}"
+        ) from err


### PR DESCRIPTION
This PR makes the dependency on `nltk` optional. If `nltk` is not present and the user attempts to use a capability of the library that requires it, then an exception will be raised with an error message containing installation instructions for `nltk`. I've added `nltk` to the packages in the `[dev]` package set for developers.