### PR TITLE
Fix for issue #173 - old controls format sometimes appear in granite 3.3 output

### DIFF
--- a/src/granite_io/io/granite_3_3/granite_3_3.py
+++ b/src/granite_io/io/granite_3_3/granite_3_3.py
@@ -72,7 +72,7 @@ class Granite3Point3InputOutputProcessor(ModelDirectInputOutputProcessor):
         generate_inputs.prompt = self.inputs_to_string(inputs)
 
         # Add skip_special_tokens = False to see citations.
-        if inputs.controls and inputs.controls.get("citations"):
+        if inputs.controls and inputs.controls.citations is not None:
             extra_body = generate_inputs.extra_body or {}
             extra_body["skip_special_tokens"] = False
             generate_inputs.extra_body = extra_body

--- a/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
+++ b/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
@@ -513,21 +513,21 @@ def _remove_controls_output_from_response_text(response_text: str) -> str:
     Issue #173, no controls were specified but sometimes appear in the output.
     Clean the response text of any controls output and return it.
     """
-    regex_citation_in_text = r" \{\"document_id\"(.*?)\}"
-    regex_control_responses_list = r"\{\"id\"(.*?)\}"
+    regex_citation_in_text = r" \{\"document_id\": \"\d+\"\}"
+    regex_control_citation_list = r"\{\"id\": \"citation\"\}"
+    regex_control_hallucination_list = r"\{\"id\": \"hallucination\"\}"
 
     cleaned = response_text
 
     # Remove all citations in the response
     cleaned = re.sub(regex_citation_in_text, "", cleaned)
 
-    # Remove the list of outputs from controls
-    # E.g. "citations", "hallucinations"
-    match = re.search(regex_control_responses_list, cleaned, re.DOTALL)
-    if match:
-        cleaned = cleaned[:match.start()]
-    return cleaned.strip()
-
+    # Remove the specific list of outputs from controls based on their regex
+    for regex_fn in [regex_control_citation_list, regex_control_hallucination_list]:
+        match = re.search(regex_fn, cleaned, re.DOTALL)
+        if match:
+            cleaned = cleaned[: match.start()].strip()
+    return cleaned
 
 
 def _validate_response(response_text: str, citation_info: object):
@@ -682,6 +682,9 @@ def parse_model_output(
 
     Args:
         model_output: The response from model request
+        inputs: The full input given to the model, required to fix issue with
+                old controls format appearing and to access documents for the
+                new citations format in the model output
     Returns:
         Parsed part of the model output as follows:
             "docs": Document references
@@ -691,13 +694,13 @@ def parse_model_output(
     }
     """
 
-    docs_from_input = inputs.documents
-
     # Issue #173, no controls were specified but old citations and hallications
     # format sometimes appear in the output.
     # Clean the response text of these old controls format.
     if inputs.controls is None:
-        response_text_without_controls = _remove_controls_output_from_response_text(model_output)
+        response_text_without_controls = _remove_controls_output_from_response_text(
+            model_output
+        )
         result = {
             "docs": None,
             "response": response_text_without_controls,
@@ -706,6 +709,8 @@ def parse_model_output(
         }
         logger.debug(f"Response text without controls:\n{result}\n")
         return result
+
+    docs_from_input = inputs.documents
 
     # Split model output into its parts: response, citation, and hallucination section
     response_text, citations_text, hallucinations_text = _split_model_output_into_parts(

--- a/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
+++ b/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
@@ -514,8 +514,7 @@ def _remove_controls_output_from_response_text(response_text: str) -> str:
     Clean the response text of any controls output and return it.
     """
     regex_citation_in_text = r" \{\"document_id\": \"\d+\"\}"
-    regex_control_citation_list = r"\{\"id\": \"citation\"\}"
-    regex_control_hallucination_list = r"\{\"id\": \"hallucination\"\}"
+    regex_control_responses_list = r"\{\"id\": \"(citation|hallucination)\"\}"
 
     cleaned = response_text
 
@@ -523,10 +522,9 @@ def _remove_controls_output_from_response_text(response_text: str) -> str:
     cleaned = re.sub(regex_citation_in_text, "", cleaned)
 
     # Remove the specific list of outputs from controls based on their regex
-    for regex_fn in [regex_control_citation_list, regex_control_hallucination_list]:
-        match = re.search(regex_fn, cleaned, re.DOTALL)
-        if match:
-            cleaned = cleaned[: match.start()].strip()
+    match = re.search(regex_control_responses_list, cleaned, re.DOTALL)
+    if match:
+        cleaned = cleaned[: match.start()].strip()
     return cleaned
 
 

--- a/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
+++ b/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
@@ -39,6 +39,9 @@ from granite_io.io.consts import (
     _GRANITE_3_3_CITE_START,
     _GRANITE_3_3_HALLUCINATIONS_START,
 )
+from granite_io.io.granite_3_3.input_processors.granite_3_3_input_processor import (
+    Granite3Point3Inputs,
+)
 
 # Setup logger
 logger = logging.getLogger("granite_io.io.granite_3_3.output_parser")
@@ -504,6 +507,28 @@ def _remove_citations_from_response_text(response_text: str) -> str:
     return re.sub(pattern, "", ret).strip()
 
 
+def _remove_controls_output_from_response_text(response_text: str) -> str:
+    """
+    Issue #173, no controls were specified but sometimes appear in the output.
+    Clean the response text of any controls output and return it.
+    """
+    regex_citation_in_text = r" \{\"document_id\"(.*?)\}"
+    regex_control_responses_list = r"\{\"id\"(.*?)\}"
+
+    cleaned = response_text
+
+    # Remove all citations in the response
+    cleaned = re.sub(regex_citation_in_text, "", cleaned)
+
+    # Remove the list of outputs from controls
+    # E.g. "citations", "hallucinations"
+    match = re.search(regex_control_responses_list, cleaned, re.DOTALL)
+    if match:
+        cleaned = cleaned[:match.start()]
+    return cleaned.strip()
+
+
+
 def _validate_response(response_text: str, citation_info: object):
     start = re.escape(_GRANITE_3_3_CITE_START)
     end = re.escape(_GRANITE_3_3_CITE_END)
@@ -648,7 +673,7 @@ def _update_docs_text_with_input_docs(
 
 
 def parse_model_output(
-    model_output: str, docs_from_input: list[object]
+    model_output: str, inputs: Granite3Point3Inputs
 ) -> list[str | dict]:
     """
     Parse the constituents of the output (response) of a model into
@@ -664,6 +689,22 @@ def parse_model_output(
             "hallucinations": Hallucinations
     }
     """
+
+    docs_from_input = inputs.documents
+
+    # Issue #173, no controls were specified but old citations and hallications
+    # format sometimes appear in the output.
+    # Clean the response text of these old controls format.
+    if inputs.controls is None:
+        response_text_without_controls = _remove_controls_output_from_response_text(model_output)
+        result = {
+            "docs": None,
+            "response": response_text_without_controls,
+            "citations": None,
+            "hallucinations": None,
+        }
+        logger.debug(f"Response text without controls:\n{result}\n")
+        return result
 
     # Split model output into its parts: response, citation, and hallucination section
     response_text, citations_text, hallucinations_text = _split_model_output_into_parts(

--- a/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
+++ b/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
@@ -36,10 +36,10 @@ from granite_io.io.consts import (
     _GRANITE_3_3_CITE_START,
     _GRANITE_3_3_HALLUCINATIONS_START,
 )
-from granite_io.optional import nltk_check
 from granite_io.io.granite_3_3.input_processors.granite_3_3_input_processor import (
     Granite3Point3Inputs,
 )
+from granite_io.optional import nltk_check
 
 # Setup logger
 logger = logging.getLogger("granite_io.io.granite_3_3.output_parser")

--- a/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_processor.py
+++ b/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_processor.py
@@ -156,7 +156,7 @@ class Granite3Point3OutputProcessor(OutputProcessor):
 
             # Parse out citations, documents and hallucinations
             try:
-                parsed_output = parse_model_output(output, inputs.documents)
+                parsed_output = parse_model_output(output, inputs)
             except Exception as err:
                 raise ValueError(
                     "Failed to parse citations, documents and hallucinations "

--- a/tests/io/granite_3_3/output_processors/test_granite_3_3_output_parser.py
+++ b/tests/io/granite_3_3/output_processors/test_granite_3_3_output_parser.py
@@ -25,8 +25,8 @@ from granite_io.io.granite_3_3.output_processors.granite_3_3_output_parser impor
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
 
 
-@pytest.fixture(scope="session")
-def inputs():
+@pytest.fixture(name="inputs", scope="session")
+def fixture_inputs():
     # Tests below do not need the inputs, but in the IO flow, an input is
     # necessary, so we create a placeholder input object.
     # Settings on this input object can be correctly enabled, as designed.
@@ -52,7 +52,7 @@ def inputs():
     }
 
 
-def test_output():
+def test_output(inputs):
     model_output = load_text_file(os.path.join(TEST_DATA_DIR, "test_output.txt"))
     parsed_output = parse_model_output(model_output, inputs["empty"])
 
@@ -71,7 +71,7 @@ def test_output():
     assert parsed_output["hallucinations"] is None
 
 
-def test_output_with_citation():
+def test_output_with_citation(inputs):
     model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_citation.txt")
     )
@@ -125,7 +125,7 @@ def test_output_with_citation():
     assert parsed_output["hallucinations"] is None
 
 
-def test_output_with_invalid_citation():
+def test_output_with_invalid_citation(inputs):
     model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_invalid_citation.txt")
     )
@@ -137,7 +137,7 @@ def test_output_with_invalid_citation():
     assert parsed_output["hallucinations"] is None
 
 
-def test_output_with_colons_in_citation_text():
+def test_output_with_colons_in_citation_text(inputs):
     model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_colons_citation_text.txt")
     )
@@ -204,7 +204,7 @@ def test_output_with_colons_in_citation_text():
         hallc_id += 1
 
 
-def test_output_with_citation_hallucinations():
+def test_output_with_citation_hallucinations(inputs):
     model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_citation_hallucinations.txt")
     )
@@ -274,7 +274,7 @@ def test_output_with_citation_hallucinations():
         hallc_id += 1
 
 
-def test_output_with_citation_from_source():
+def test_output_with_citation_from_source(inputs):
     model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_citation_from_source.txt")
     )
@@ -332,7 +332,7 @@ def test_output_with_citation_from_source():
     assert parsed_output["hallucinations"] is None
 
 
-def test_output_with_multiple_citations_per_document():
+def test_output_with_multiple_citations_per_document(inputs):
     model_output = load_text_file(
         os.path.join(
             TEST_DATA_DIR, "test_output_with_multiple_citations_per_document.txt"

--- a/tests/io/granite_3_3/output_processors/test_granite_3_3_output_parser.py
+++ b/tests/io/granite_3_3/output_processors/test_granite_3_3_output_parser.py
@@ -7,16 +7,16 @@ Tests for the model output parser
 
 # Standard
 import os
-import pytest
 
 # Third Party
 from test_utils import load_text_file
+import pytest
 
 # Local
 from granite_io.io.granite_3_3.input_processors.granite_3_3_input_processor import (
-    Granite3Point3Inputs,
     ControlsRecord,
     Document,
+    Granite3Point3Inputs,
 )
 from granite_io.io.granite_3_3.output_processors.granite_3_3_output_parser import (
     parse_model_output,
@@ -24,12 +24,15 @@ from granite_io.io.granite_3_3.output_processors.granite_3_3_output_parser impor
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
 
+
 @pytest.fixture(scope="session")
 def inputs():
     # Tests below do not need the inputs, but in the IO flow, an input is
     # necessary, so we create a placeholder input object.
     # Settings on this input object can be correctly enabled, as designed.
-    empty = Granite3Point3Inputs.model_validate({"messages": [{"role": "user", "content": ""}]})
+    empty = Granite3Point3Inputs.model_validate(
+        {"messages": [{"role": "user", "content": ""}]}
+    )
 
     empty_with_citations = empty.model_copy()
     controls_citation = ControlsRecord()
@@ -48,7 +51,8 @@ def inputs():
         "empty_with_citation_hallucination_controls": empty_with_citations_hallucinations,
     }
 
-def test_output(inputs):
+
+def test_output():
     model_output = load_text_file(os.path.join(TEST_DATA_DIR, "test_output.txt"))
     parsed_output = parse_model_output(model_output, inputs["empty"])
 
@@ -67,11 +71,13 @@ def test_output(inputs):
     assert parsed_output["hallucinations"] is None
 
 
-def test_output_with_citation(inputs):
+def test_output_with_citation():
     model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_citation.txt")
     )
-    parsed_output = parse_model_output(model_output, inputs["empty_with_citation_control"])
+    parsed_output = parse_model_output(
+        model_output, inputs["empty_with_citation_control"]
+    )
 
     assert parsed_output
     assert isinstance(parsed_output, dict)
@@ -119,21 +125,25 @@ def test_output_with_citation(inputs):
     assert parsed_output["hallucinations"] is None
 
 
-def test_output_with_invalid_citation(inputs):
+def test_output_with_invalid_citation():
     model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_invalid_citation.txt")
     )
-    parsed_output = parse_model_output(model_output, inputs["empty_with_citation_control"])
+    parsed_output = parse_model_output(
+        model_output, inputs["empty_with_citation_control"]
+    )
 
     assert parsed_output["citations"] is None
     assert parsed_output["hallucinations"] is None
 
 
-def test_output_with_colons_in_citation_text(inputs):
+def test_output_with_colons_in_citation_text():
     model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_colons_citation_text.txt")
     )
-    parsed_output = parse_model_output(model_output, inputs["empty_with_citation_control"])
+    parsed_output = parse_model_output(
+        model_output, inputs["empty_with_citation_control"]
+    )
 
     assert parsed_output
     assert isinstance(parsed_output, dict)
@@ -194,11 +204,13 @@ def test_output_with_colons_in_citation_text(inputs):
         hallc_id += 1
 
 
-def test_output_with_citation_hallucinations(inputs):
+def test_output_with_citation_hallucinations():
     model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_citation_hallucinations.txt")
     )
-    parsed_output = parse_model_output(model_output, inputs["empty_with_citation_hallucination_controls"])
+    parsed_output = parse_model_output(
+        model_output, inputs["empty_with_citation_hallucination_controls"]
+    )
 
     assert parsed_output
     assert isinstance(parsed_output, dict)
@@ -262,7 +274,7 @@ def test_output_with_citation_hallucinations(inputs):
         hallc_id += 1
 
 
-def test_output_with_citation_from_source(inputs):
+def test_output_with_citation_from_source():
     model_output = load_text_file(
         os.path.join(TEST_DATA_DIR, "test_output_with_citation_from_source.txt")
     )
@@ -320,13 +332,15 @@ def test_output_with_citation_from_source(inputs):
     assert parsed_output["hallucinations"] is None
 
 
-def test_output_with_multiple_citations_per_document(inputs):
+def test_output_with_multiple_citations_per_document():
     model_output = load_text_file(
         os.path.join(
             TEST_DATA_DIR, "test_output_with_multiple_citations_per_document.txt"
         )
     )
-    parsed_output = parse_model_output(model_output, inputs["empty_with_citation_control"])
+    parsed_output = parse_model_output(
+        model_output, inputs["empty_with_citation_control"]
+    )
 
     assert parsed_output
     assert isinstance(parsed_output, dict)

--- a/tests/io/granite_3_3/test_granite_3_3.py
+++ b/tests/io/granite_3_3/test_granite_3_3.py
@@ -449,6 +449,13 @@ def test_citation_hallucination_parsing(
     inputs, output, exp_document, exp_citation, exp_hallucination, exp_resp
 ):
     """Test the parsing logic for Rag and hallucinations output"""
+
+    # Controls must be explicitly enabled, see issue #173.
+    controls = ControlsRecord()
+    controls.citations = True
+    controls.hallucinations = True
+    inputs.controls = controls
+
     proc = Granite3Point3InputOutputProcessor()
     generated = GenerateResults(
         results=[


### PR DESCRIPTION
Fix for issue #173. (Also fixes issue #156.)

Added a check and function to clean the old controls format. The new check `inputs.controls is None` enables the cleaning when no explicit controls have been specified.

Notebook to demonstrate fix: [granite-3_3-issue173-fix.ipynb.zip](https://github.com/user-attachments/files/20354973/granite-3_3-issue173-fix.ipynb.zip)

CSV comparing the three outputs: [granite-3_3-issue173-fix.csv](https://github.com/user-attachments/files/20355067/granite-3_3-issue173-fix.csv)
- `without_fix_no_controls` - old controls format appears in some response outputs
- `with_fix_no_controls` - with fix, no controls can be seen in the response output
- `with_fix_with_controls` - enabling the controls, correctly outputs the new controls format
