### PR TITLE
Remove output from notebook

### DIFF
--- a/notebooks/hallucinations.ipynb
+++ b/notebooks/hallucinations.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,123 +53,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c24191c4eaee46399f222df91e7abc6c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Fetching 10 files:   0%|          | 0/10 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Local path to LoRA adapter: /home/freiss/.cache/huggingface/hub/models--ibm-granite--granite-3.3-8b-rag-agent-lib/snapshots/310479c72458e1ebbad00baa010a37b0003f89c8/hallucination_detection_lora\n",
-      "INFO 11:32:20 Running: /mnt/nvmedisk/freiss/granite/env/bin/vllm serve ibm-granite/granite-3.3-8b-instruct --port 32979 --gpu-memory-utilization 0.45 --max-model-len 32768 --guided_decoding_backend outlines --device auto --enforce-eager --enable-lora --max_lora_rank 64 --lora-modules hallucination_detection=/home/freiss/.cache/huggingface/hub/models--ibm-granite--granite-3.3-8b-rag-agent-lib/snapshots/310479c72458e1ebbad00baa010a37b0003f89c8/hallucination_detection_lora\n",
-      "INFO 06-13 11:32:26 [__init__.py:243] Automatically detected platform cuda.\n",
-      "INFO 06-13 11:32:30 [__init__.py:31] Available plugins for group vllm.general_plugins:\n",
-      "INFO 06-13 11:32:30 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver\n",
-      "INFO 06-13 11:32:30 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.\n",
-      "INFO 06-13 11:32:33 [api_server.py:1289] vLLM API server version 0.9.0.1\n",
-      "INFO 06-13 11:32:34 [cli_args.py:300] non-default args: {'port': 32979, 'lora_modules': [LoRAModulePath(name='hallucination_detection', path='/home/freiss/.cache/huggingface/hub/models--ibm-granite--granite-3.3-8b-rag-agent-lib/snapshots/310479c72458e1ebbad00baa010a37b0003f89c8/hallucination_detection_lora', base_model_name=None)], 'max_model_len': 32768, 'enforce_eager': True, 'guided_decoding_backend': 'outlines', 'gpu_memory_utilization': 0.45, 'enable_lora': True, 'max_lora_rank': 64}\n",
-      "INFO 06-13 11:32:46 [config.py:793] This model supports multiple tasks: {'score', 'generate', 'reward', 'embed', 'classify'}. Defaulting to 'generate'.\n",
-      "WARNING 06-13 11:32:46 [arg_utils.py:1583] --guided-decoding-backend=outlines is not supported by the V1 Engine. Falling back to V0. \n",
-      "WARNING 06-13 11:32:46 [cuda.py:87] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used\n",
-      "INFO 06-13 11:32:46 [api_server.py:257] Started engine process with PID 923124\n",
-      "INFO 06-13 11:32:51 [__init__.py:243] Automatically detected platform cuda.\n",
-      "INFO 06-13 11:32:56 [__init__.py:31] Available plugins for group vllm.general_plugins:\n",
-      "INFO 06-13 11:32:56 [__init__.py:33] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver\n",
-      "INFO 06-13 11:32:56 [__init__.py:36] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.\n",
-      "INFO 06-13 11:32:56 [llm_engine.py:230] Initializing a V0 LLM engine (v0.9.0.1) with config: model='ibm-granite/granite-3.3-8b-instruct', speculative_config=None, tokenizer='ibm-granite/granite-3.3-8b-instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(backend='outlines', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=ibm-granite/granite-3.3-8b-instruct, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=None, chunked_prefill_enabled=False, use_async_output_proc=False, pooler_config=None, compilation_config={\"compile_sizes\": [], \"inductor_compile_config\": {\"enable_auto_functionalized_v2\": false}, \"cudagraph_capture_sizes\": [], \"max_capture_size\": 0}, use_cached_outputs=True, \n",
-      "INFO 06-13 11:32:57 [cuda.py:292] Using Flash Attention backend.\n",
-      "INFO 06-13 11:33:00 [parallel_state.py:1064] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0\n",
-      "INFO 06-13 11:33:00 [model_runner.py:1170] Starting to load model ibm-granite/granite-3.3-8b-instruct...\n",
-      "INFO 06-13 11:33:01 [weight_utils.py:291] Using model weights format ['*.safetensors']\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]\n",
-      "Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:00<00:01,  1.96it/s]\n",
-      "Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:02<00:02,  1.25s/it]\n",
-      "Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:04<00:01,  1.47s/it]\n",
-      "Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:05<00:00,  1.56s/it]\n",
-      "Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:05<00:00,  1.43s/it]\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO 06-13 11:33:07 [default_loader.py:280] Loading weights took 5.88 seconds\n",
-      "INFO 06-13 11:33:07 [punica_selector.py:18] Using PunicaWrapperGPU.\n",
-      "INFO 06-13 11:33:08 [model_runner.py:1202] Model loading took 15.6407 GiB and 6.912470 seconds\n",
-      "INFO 06-13 11:33:13 [worker.py:291] Memory profiling takes 4.96 seconds\n",
-      "INFO 06-13 11:33:13 [worker.py:291] the current vLLM instance can use total_gpu_memory (79.25GiB) x gpu_memory_utilization (0.45) = 35.66GiB\n",
-      "INFO 06-13 11:33:13 [worker.py:291] model weights take 15.64GiB; non_torch_memory takes 0.09GiB; PyTorch activation peak memory takes 3.36GiB; the rest of the memory reserved for KV Cache is 16.57GiB.\n",
-      "INFO 06-13 11:33:13 [executor_base.py:112] # cuda blocks: 6787, # CPU blocks: 1638\n",
-      "INFO 06-13 11:33:13 [executor_base.py:117] Maximum concurrency for 32768 tokens per request: 3.31x\n",
-      "INFO 06-13 11:33:16 [llm_engine.py:428] init engine (profile, create kv cache, warmup model) took 8.12 seconds\n",
-      "INFO 06-13 11:33:16 [serving_models.py:185] Loaded new LoRA adapter: name 'hallucination_detection', path '/home/freiss/.cache/huggingface/hub/models--ibm-granite--granite-3.3-8b-rag-agent-lib/snapshots/310479c72458e1ebbad00baa010a37b0003f89c8/hallucination_detection_lora'\n",
-      "INFO 06-13 11:33:16 [api_server.py:1336] Starting vLLM API server on http://0.0.0.0:32979\n",
-      "INFO 06-13 11:33:16 [launcher.py:28] Available routes are:\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /openapi.json, Methods: GET, HEAD\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /docs, Methods: GET, HEAD\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /docs/oauth2-redirect, Methods: GET, HEAD\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /redoc, Methods: GET, HEAD\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /health, Methods: GET\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /load, Methods: GET\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /ping, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /ping, Methods: GET\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /tokenize, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /detokenize, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /v1/models, Methods: GET\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /version, Methods: GET\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /v1/chat/completions, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /v1/completions, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /v1/embeddings, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /pooling, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /classify, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /score, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /v1/score, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /v1/audio/transcriptions, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /rerank, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /v1/rerank, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /v2/rerank, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /invocations, Methods: POST\n",
-      "INFO 06-13 11:33:16 [launcher.py:36] Route: /metrics, Methods: GET\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:     Started server process [922820]\n",
-      "INFO:     Waiting for application startup.\n",
-      "INFO:     Application startup complete.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:     127.0.0.1:49338 - \"GET /ping HTTP/1.1\" 200 OK\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if run_server:\n",
     "    # Start by firing up a local vLLM server and connecting a backend instance to it.\n",
@@ -209,20 +95,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Granite3Point3Inputs(messages=[UserMessage(content='What is the visibility level of Git Repos and Issue Tracking projects?', role='user')], tools=[], generate_inputs=GenerateInputs(prompt=None, model=None, best_of=None, echo=None, frequency_penalty=None, logit_bias=None, logprobs=None, max_tokens=1024, n=None, presence_penalty=None, stop=None, stream=None, stream_options=None, suffix=None, temperature=0.0, top_p=None, user=None, extra_headers=None, extra_body={}), documents=[Document(text='Git Repos and Issue Tracking is an IBM-hosted component of the Continuous Delivery service. All of the data that you provide to Git Repos and Issue Tracking, including but not limited to source files, issues, pull requests, and project configuration properties, is managed securely within Continuous Delivery. However, Git Repos and Issue Tracking supports various mechanisms for exporting, sending, or otherwise sharing data to users and third parties. The ability of Git Repos and Issue Tracking to share information is typical of many social coding platforms. However, such sharing might conflict with regulatory controls that apply to your business. After you create a project in Git Repos and Issue Tracking, but before you entrust any files, issues, records, or other data with the project, review the project settings and change any settings that you deem necessary to protect your data. Settings to review include visibility levels, email notifications, integrations, web hooks, access tokens, deploy tokens, and deploy keys. Project visibility levels \\n\\nGit Repos and Issue Tracking projects can have one of the following visibility levels: private, internal, or public. * Private projects are visible only to project members. This setting is the default visibility level for new projects, and is the most secure visibility level for your data. * Internal projects are visible to all users that are logged in to IBM Cloud. * Public projects are visible to anyone. To limit project access to only project members, complete the following steps:\\n\\n\\n\\n1. From the project sidebar, click Settings > General. 2. On the General Settings page, click Visibility > project features > permissions. 3. Locate the Project visibility setting. 4. Select Private, if it is not already selected. 5. Click Save changes. Project membership \\n\\nGit Repos and Issue Tracking is a cloud hosted social coding environment that is available to all Continuous Delivery users. If you are a Git Repos and Issue Tracking project Maintainer or Owner, you can invite any user and group members to the project. IBM Cloud places no restrictions on who you can invite to a project.'), Document(text='After you create a project in Git Repos and Issue Tracking, but before you entrust any files, issues, records, or other data with the project, review the project settings and change any settings that are necessary to protect your data. Settings to review include visibility levels, email notifications, integrations, web hooks, access tokens, deploy tokens, and deploy keys. Project visibility levels \\n\\nGit Repos and Issue Tracking projects can have one of the following visibility levels: private, internal, or public. * Private projects are visible only to project members. This setting is the default visibility level for new projects, and is the most secure visibility level for your data. * Internal projects are visible to all users that are logged in to IBM Cloud. * Public projects are visible to anyone. To limit project access to only project members, complete the following steps:\\n\\n\\n\\n1. From the project sidebar, click Settings > General. 2. On the General Settings page, click Visibility > project features > permissions. 3. Locate the Project visibility setting. 4. Select Private, if it is not already selected. 5. Click Save changes. Project email settings \\n\\nBy default, Git Repos and Issue Tracking notifies project members by way of email about project activities. These emails typically include customer-owned data that was provided to Git Repos and Issue Tracking by users. For example, if a user posts a comment to an issue, Git Repos and Issue Tracking sends an email to all subscribers. The email includes information such as a copy of the comment, the user who posted it, and when the comment was posted. To turn off all email notifications for your project, complete the following steps:\\n\\n\\n\\n1. From the project sidebar, click Settings > General. 2. On the **General Settings **page, click Visibility > project features > permissions. 3. Select the Disable email notifications checkbox. 4. Click Save changes. Project integrations and webhooks')], controls=None, thinking=False)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create an example chat completion with a user question and two documents.\n",
     "chat_input = Granite3Point3Inputs.model_validate(\n",
@@ -301,32 +176,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO 06-13 11:33:18 [logger.py:42] Received request cmpl-cfd8fa0e9aed4d5ba543c3370e6d6a79-0: prompt: '<|start_of_role|>system<|end_of_role|>Knowledge Cutoff Date: April 2024.\\nToday\\'s Date: June 13, 2025.\\nYou are Granite, developed by IBM. Write the response to the user\\'s input by strictly aligning with the facts in the provided documents. If the information needed to answer the question is not available in the documents, inform the user that the question cannot be answered based on the available data.<|end_of_text|>\\n<|start_of_role|>document {\"document_id\": \"1\"}<|end_of_role|>\\nGit Repos and Issue Tracking is an IBM-hosted component of the Continuous Delivery service. All of the data that you provide to Git Repos and Issue Tracking, including but not limited to source files, issues, pull requests, and project configuration properties, is managed securely within Continuous Delivery. However, Git Repos and Issue Tracking supports various mechanisms for exporting, sending, or otherwise sharing data to users and third parties. The ability of Git Repos and Issue Tracking to share information is typical of many social coding platforms. However, such sharing might conflict with regulatory controls that apply to your business. After you create a project in Git Repos and Issue Tracking, but before you entrust any files, issues, records, or other data with the project, review the project settings and change any settings that you deem necessary to protect your data. Settings to review include visibility levels, email notifications, integrations, web hooks, access tokens, deploy tokens, and deploy keys. Project visibility levels \\n\\nGit Repos and Issue Tracking projects can have one of the following visibility levels: private, internal, or public. * Private projects are visible only to project members. This setting is the default visibility level for new projects, and is the most secure visibility level for your data. * Internal projects are visible to all users that are logged in to IBM Cloud. * Public projects are visible to anyone. To limit project access to only project members, complete the following steps:\\n\\n\\n\\n1. From the project sidebar, click Settings > General. 2. On the General Settings page, click Visibility > project features > permissions. 3. Locate the Project visibility setting. 4. Select Private, if it is not already selected. 5. Click Save changes. Project membership \\n\\nGit Repos and Issue Tracking is a cloud hosted social coding environment that is available to all Continuous Delivery users. If you are a Git Repos and Issue Tracking project Maintainer or Owner, you can invite any user and group members to the project. IBM Cloud places no restrictions on who you can invite to a project.<|end_of_text|>\\n<|start_of_role|>document {\"document_id\": \"2\"}<|end_of_role|>\\nAfter you create a project in Git Repos and Issue Tracking, but before you entrust any files, issues, records, or other data with the project, review the project settings and change any settings that are necessary to protect your data. Settings to review include visibility levels, email notifications, integrations, web hooks, access tokens, deploy tokens, and deploy keys. Project visibility levels \\n\\nGit Repos and Issue Tracking projects can have one of the following visibility levels: private, internal, or public. * Private projects are visible only to project members. This setting is the default visibility level for new projects, and is the most secure visibility level for your data. * Internal projects are visible to all users that are logged in to IBM Cloud. * Public projects are visible to anyone. To limit project access to only project members, complete the following steps:\\n\\n\\n\\n1. From the project sidebar, click Settings > General. 2. On the General Settings page, click Visibility > project features > permissions. 3. Locate the Project visibility setting. 4. Select Private, if it is not already selected. 5. Click Save changes. Project email settings \\n\\nBy default, Git Repos and Issue Tracking notifies project members by way of email about project activities. These emails typically include customer-owned data that was provided to Git Repos and Issue Tracking by users. For example, if a user posts a comment to an issue, Git Repos and Issue Tracking sends an email to all subscribers. The email includes information such as a copy of the comment, the user who posted it, and when the comment was posted. To turn off all email notifications for your project, complete the following steps:\\n\\n\\n\\n1. From the project sidebar, click Settings > General. 2. On the **General Settings **page, click Visibility > project features > permissions. 3. Select the Disable email notifications checkbox. 4. Click Save changes. Project integrations and webhooks<|end_of_text|><|start_of_role|>user<|end_of_role|>What is the visibility level of Git Repos and Issue Tracking projects?<|end_of_text|>\\n<|start_of_role|>assistant<|end_of_role|>', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=1024, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: [49152, 2946, 49153, 39558, 390, 17071, 2821, 44, 30468, 225, 36, 34, 36, 38, 32, 203, 23669, 1182, 2821, 44, 30422, 225, 35, 37, 30, 225, 36, 34, 36, 39, 32, 203, 4282, 884, 8080, 278, 659, 30, 18909, 810, 25697, 32, 5950, 322, 1789, 372, 322, 1256, 1182, 1509, 810, 33220, 3014, 299, 623, 322, 44052, 328, 322, 3943, 12827, 32, 1670, 322, 2471, 5349, 372, 7592, 322, 7000, 438, 646, 3304, 328, 322, 12827, 30, 7956, 322, 1256, 688, 322, 7000, 4881, 526, 40031, 4122, 544, 322, 3304, 706, 32, 0, 203, 49152, 2812, 3447, 2812, 81, 314, 563, 313, 35, 3612, 49153, 203, 7546, 902, 966, 461, 13622, 35451, 438, 600, 25697, 31, 28561, 2577, 432, 322, 47021, 31878, 2719, 32, 3367, 432, 322, 706, 688, 844, 2355, 372, 5575, 902, 966, 461, 13622, 35451, 30, 6237, 1273, 646, 14943, 372, 1914, 2276, 30, 5654, 30, 5083, 5167, 30, 461, 2074, 3488, 4308, 30, 438, 12852, 14706, 631, 4797, 47021, 31878, 32, 8746, 30, 5575, 902, 966, 461, 13622, 35451, 9567, 10297, 39772, 436, 45759, 30, 11926, 30, 556, 5878, 21724, 706, 372, 4250, 461, 10970, 35443, 32, 886, 13609, 432, 5575, 902, 966, 461, 13622, 35451, 372, 8623, 2471, 438, 28531, 432, 5075, 15332, 10613, 17503, 32, 8746, 30, 3751, 21724, 4796, 11730, 623, 2834, 45453, 12570, 688, 4871, 372, 1370, 12590, 32, 9723, 844, 1487, 312, 2074, 328, 5575, 902, 966, 461, 13622, 35451, 30, 1273, 2670, 844, 1663, 7421, 1346, 2276, 30, 5654, 30, 9212, 30, 556, 1604, 706, 623, 322, 2074, 30, 6119, 322, 2074, 4070, 461, 1539, 1346, 4070, 688, 844, 409, 405, 7506, 372, 23809, 1370, 706, 32, 9923, 372, 6119, 2305, 16709, 13021, 30, 4096, 15873, 30, 5845, 993, 30, 2676, 21042, 30, 2857, 7937, 30, 5625, 7937, 30, 461, 5625, 5036, 32, 5412, 16709, 13021, 1659, 203, 7546, 902, 966, 461, 13622, 35451, 8528, 883, 1159, 1591, 432, 322, 2412, 16709, 13021, 44, 945, 30, 3568, 30, 556, 562, 32, 319, 12400, 8528, 884, 8702, 1755, 372, 2074, 8999, 32, 1348, 5748, 438, 322, 1244, 16709, 3193, 436, 537, 8528, 30, 461, 438, 322, 4630, 14706, 16709, 3193, 436, 1370, 706, 32, 319, 11540, 8528, 884, 8702, 372, 1169, 4250, 688, 884, 12946, 328, 372, 25697, 7578, 32, 319, 5056, 8528, 884, 8702, 372, 15157, 32, 2614, 2723, 2074, 2857, 372, 1755, 2074, 8999, 30, 6153, 322, 2412, 6655, 44, 2831, 203, 35, 32, 8649, 322, 2074, 19372, 30, 5021, 9923, 848, 6146, 32, 225, 36, 32, 2704, 322, 6146, 9923, 1938, 30, 5021, 32169, 848, 2074, 5359, 848, 4227, 32, 225, 37, 32, 4591, 332, 322, 5412, 16709, 5748, 32, 225, 38, 32, 6608, 12400, 30, 415, 561, 438, 646, 3425, 4324, 32, 225, 39, 32, 11854, 9875, 3404, 32, 5412, 26050, 1659, 203, 7546, 902, 966, 461, 13622, 35451, 438, 312, 8668, 25966, 15332, 10613, 4706, 688, 438, 3304, 372, 1169, 47021, 31878, 4250, 32, 1670, 844, 884, 312, 5575, 902, 966, 461, 13622, 35451, 2074, 30398, 1352, 556, 24543, 30, 844, 883, 31207, 1346, 1256, 461, 2350, 8999, 372, 322, 2074, 32, 25697, 7578, 15307, 1289, 26808, 544, 6560, 844, 883, 31207, 372, 312, 2074, 32, 0, 203, 49152, 2812, 3447, 2812, 81, 314, 563, 313, 36, 3612, 49153, 203, 5125, 844, 1487, 312, 2074, 328, 5575, 902, 966, 461, 13622, 35451, 30, 1273, 2670, 844, 1663, 7421, 1346, 2276, 30, 5654, 30, 9212, 30, 556, 1604, 706, 623, 322, 2074, 30, 6119, 322, 2074, 4070, 461, 1539, 1346, 4070, 688, 884, 7506, 372, 23809, 1370, 706, 32, 9923, 372, 6119, 2305, 16709, 13021, 30, 4096, 15873, 30, 5845, 993, 30, 2676, 21042, 30, 2857, 7937, 30, 5625, 7937, 30, 461, 5625, 5036, 32, 5412, 16709, 13021, 1659, 203, 7546, 902, 966, 461, 13622, 35451, 8528, 883, 1159, 1591, 432, 322, 2412, 16709, 13021, 44, 945, 30, 3568, 30, 556, 562, 32, 319, 12400, 8528, 884, 8702, 1755, 372, 2074, 8999, 32, 1348, 5748, 438, 322, 1244, 16709, 3193, 436, 537, 8528, 30, 461, 438, 322, 4630, 14706, 16709, 3193, 436, 1370, 706, 32, 319, 11540, 8528, 884, 8702, 372, 1169, 4250, 688, 884, 12946, 328, 372, 25697, 7578, 32, 319, 5056, 8528, 884, 8702, 372, 15157, 32, 2614, 2723, 2074, 2857, 372, 1755, 2074, 8999, 30, 6153, 322, 2412, 6655, 44, 2831, 203, 35, 32, 8649, 322, 2074, 19372, 30, 5021, 9923, 848, 6146, 32, 225, 36, 32, 2704, 322, 6146, 9923, 1938, 30, 5021, 32169, 848, 2074, 5359, 848, 4227, 32, 225, 37, 32, 4591, 332, 322, 5412, 16709, 5748, 32, 225, 38, 32, 6608, 12400, 30, 415, 561, 438, 646, 3425, 4324, 32, 225, 39, 32, 11854, 9875, 3404, 32, 5412, 4096, 4070, 1659, 203, 1083, 1244, 30, 5575, 902, 966, 461, 13622, 35451, 646, 6856, 2074, 8999, 810, 3352, 432, 4096, 2625, 2074, 22076, 32, 8204, 26914, 18214, 2305, 9697, 31, 21152, 706, 688, 1597, 3943, 372, 5575, 902, 966, 461, 13622, 35451, 810, 4250, 32, 2616, 2280, 30, 415, 312, 1256, 14765, 312, 5093, 372, 600, 2427, 30, 5575, 902, 966, 461, 13622, 35451, 18613, 600, 4096, 372, 1169, 40660, 32, 886, 4096, 8600, 2471, 3751, 619, 312, 1933, 432, 322, 5093, 30, 322, 1256, 6560, 21464, 561, 30, 461, 1412, 322, 5093, 1597, 21464, 32, 2614, 6927, 2126, 1169, 4096, 15873, 436, 1370, 2074, 30, 6153, 322, 2412, 6655, 44, 2831, 203, 35, 32, 8649, 322, 2074, 19372, 30, 5021, 9923, 848, 6146, 32, 225, 36, 32, 2704, 322, 1115, 8627, 9923, 1115, 1637, 30, 5021, 32169, 848, 2074, 5359, 848, 4227, 32, 225, 37, 32, 6608, 322, 17616, 4096, 15873, 20569, 32, 225, 38, 32, 11854, 9875, 3404, 32, 5412, 5845, 993, 461, 2676, 12329, 0, 49152, 496, 49153, 8197, 438, 322, 16709, 3193, 432, 5575, 902, 966, 461, 13622, 35451, 8528, 49, 0, 203, 49152, 17594, 49153], prompt_embeds shape: None, lora_request: None, prompt_adapter_request: None.\n",
-      "INFO 06-13 11:33:18 [engine.py:316] Added request cmpl-cfd8fa0e9aed4d5ba543c3370e6d6a79-0.\n",
-      "INFO 06-13 11:33:21 [metrics.py:486] Avg prompt throughput: 192.0 tokens/s, Avg generation throughput: 9.1 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.9%, CPU KV cache usage: 0.0%.\n",
-      "INFO:     127.0.0.1:49352 - \"POST /v1/completions HTTP/1.1\" 200 OK\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "Git Repos and Issue Tracking projects can have one of three visibility levels: private, internal, or public. Private projects are visible only to project members, internal projects are visible to all logged-in IBM Cloud users, and public projects are visible to anyone."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Pass the example input through Granite 3.3 to get an answer\n",
     "granite_io_proc = make_io_processor(\"Granite 3.3\", backend=backend)\n",
@@ -337,21 +189,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[UserMessage(content='What is the visibility level of Git Repos and Issue Tracking projects?', role='user'),\n",
-       " AssistantMessage(content='Git Repos and Issue Tracking projects can have one of three visibility levels: private, internal, or public. Private projects are visible only to project members, internal projects are visible to all logged-in IBM Cloud users, and public projects are visible to anyone.', role='assistant', tool_calls=[], reasoning_content=None, citations=None, documents=None, hallucinations=None, stop_reason='stop')]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Append the model's output to the chat\n",
     "next_chat_input = chat_input.with_next_message(result.results[0].next_message)\n",
@@ -360,48 +200,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO 06-13 11:33:23 [logger.py:42] Received request cmpl-d97864314bac4130aa5d40ed92bb27df-0: prompt: \"<|start_of_role|>system<|end_of_role|>Knowledge Cutoff Date: April 2024.\\nToday's Date: June 13, 2025.\\nYou are Granite, developed by IBM.Write the response to the user's input by strictly aligning with the facts in the provided documents. If the information needed to answer the question is not available in the documents, inform the user that the question cannot be answered based on the available data.<|end_of_text|>\\n<|start_of_role|>documents<|end_of_role|>Document 0\\nGit Repos and Issue Tracking is an IBM-hosted component of the Continuous Delivery service. All of the data that you provide to Git Repos and Issue Tracking, including but not limited to source files, issues, pull requests, and project configuration properties, is managed securely within Continuous Delivery. However, Git Repos and Issue Tracking supports various mechanisms for exporting, sending, or otherwise sharing data to users and third parties. The ability of Git Repos and Issue Tracking to share information is typical of many social coding platforms. However, such sharing might conflict with regulatory controls that apply to your business. After you create a project in Git Repos and Issue Tracking, but before you entrust any files, issues, records, or other data with the project, review the project settings and change any settings that you deem necessary to protect your data. Settings to review include visibility levels, email notifications, integrations, web hooks, access tokens, deploy tokens, and deploy keys. Project visibility levels \\n\\nGit Repos and Issue Tracking projects can have one of the following visibility levels: private, internal, or public. * Private projects are visible only to project members. This setting is the default visibility level for new projects, and is the most secure visibility level for your data. * Internal projects are visible to all users that are logged in to IBM Cloud. * Public projects are visible to anyone. To limit project access to only project members, complete the following steps:\\n\\n\\n\\n1. From the project sidebar, click Settings > General. 2. On the General Settings page, click Visibility > project features > permissions. 3. Locate the Project visibility setting. 4. Select Private, if it is not already selected. 5. Click Save changes. Project membership \\n\\nGit Repos and Issue Tracking is a cloud hosted social coding environment that is available to all Continuous Delivery users. If you are a Git Repos and Issue Tracking project Maintainer or Owner, you can invite any user and group members to the project. IBM Cloud places no restrictions on who you can invite to a project.\\n\\nDocument 1\\nAfter you create a project in Git Repos and Issue Tracking, but before you entrust any files, issues, records, or other data with the project, review the project settings and change any settings that are necessary to protect your data. Settings to review include visibility levels, email notifications, integrations, web hooks, access tokens, deploy tokens, and deploy keys. Project visibility levels \\n\\nGit Repos and Issue Tracking projects can have one of the following visibility levels: private, internal, or public. * Private projects are visible only to project members. This setting is the default visibility level for new projects, and is the most secure visibility level for your data. * Internal projects are visible to all users that are logged in to IBM Cloud. * Public projects are visible to anyone. To limit project access to only project members, complete the following steps:\\n\\n\\n\\n1. From the project sidebar, click Settings > General. 2. On the General Settings page, click Visibility > project features > permissions. 3. Locate the Project visibility setting. 4. Select Private, if it is not already selected. 5. Click Save changes. Project email settings \\n\\nBy default, Git Repos and Issue Tracking notifies project members by way of email about project activities. These emails typically include customer-owned data that was provided to Git Repos and Issue Tracking by users. For example, if a user posts a comment to an issue, Git Repos and Issue Tracking sends an email to all subscribers. The email includes information such as a copy of the comment, the user who posted it, and when the comment was posted. To turn off all email notifications for your project, complete the following steps:\\n\\n\\n\\n1. From the project sidebar, click Settings > General. 2. On the **General Settings **page, click Visibility > project features > permissions. 3. Select the Disable email notifications checkbox. 4. Click Save changes. Project integrations and webhooks<|end_of_text|>\\n<|start_of_role|>user<|end_of_role|>What is the visibility level of Git Repos and Issue Tracking projects?<|end_of_text|>\\n<|start_of_role|>assistant<|end_of_role|><r0> Git Repos and Issue Tracking projects can have one of three visibility levels: private, internal, or public. <r1> Private projects are visible only to project members, internal projects are visible to all logged-in IBM Cloud users, and public projects are visible to anyone.<|end_of_text|>\\n<|start_of_role|>system<|end_of_role|>Split the last assistant response into individual sentences. For each sentence in the last assistant response, identify the faithfulness score range. Ensure that your output includes all response sentence IDs, and for each response sentence ID, provide the corresponding faithfulness score range. The output must be a json structure.<|end_of_text|>\", params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=1024, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: [49152, 2946, 49153, 39558, 390, 17071, 2821, 44, 30468, 225, 36, 34, 36, 38, 32, 203, 23669, 1182, 2821, 44, 30422, 225, 35, 37, 30, 225, 36, 34, 36, 39, 32, 203, 4282, 884, 8080, 278, 659, 30, 18909, 810, 25697, 32, 2538, 322, 1789, 372, 322, 1256, 1182, 1509, 810, 33220, 3014, 299, 623, 322, 44052, 328, 322, 3943, 12827, 32, 1670, 322, 2471, 5349, 372, 7592, 322, 7000, 438, 646, 3304, 328, 322, 12827, 30, 7956, 322, 1256, 688, 322, 7000, 4881, 526, 40031, 4122, 544, 322, 3304, 706, 32, 0, 203, 49152, 17274, 49153, 3092, 225, 34, 203, 7546, 902, 966, 461, 13622, 35451, 438, 600, 25697, 31, 28561, 2577, 432, 322, 47021, 31878, 2719, 32, 3367, 432, 322, 706, 688, 844, 2355, 372, 5575, 902, 966, 461, 13622, 35451, 30, 6237, 1273, 646, 14943, 372, 1914, 2276, 30, 5654, 30, 5083, 5167, 30, 461, 2074, 3488, 4308, 30, 438, 12852, 14706, 631, 4797, 47021, 31878, 32, 8746, 30, 5575, 902, 966, 461, 13622, 35451, 9567, 10297, 39772, 436, 45759, 30, 11926, 30, 556, 5878, 21724, 706, 372, 4250, 461, 10970, 35443, 32, 886, 13609, 432, 5575, 902, 966, 461, 13622, 35451, 372, 8623, 2471, 438, 28531, 432, 5075, 15332, 10613, 17503, 32, 8746, 30, 3751, 21724, 4796, 11730, 623, 2834, 45453, 12570, 688, 4871, 372, 1370, 12590, 32, 9723, 844, 1487, 312, 2074, 328, 5575, 902, 966, 461, 13622, 35451, 30, 1273, 2670, 844, 1663, 7421, 1346, 2276, 30, 5654, 30, 9212, 30, 556, 1604, 706, 623, 322, 2074, 30, 6119, 322, 2074, 4070, 461, 1539, 1346, 4070, 688, 844, 409, 405, 7506, 372, 23809, 1370, 706, 32, 9923, 372, 6119, 2305, 16709, 13021, 30, 4096, 15873, 30, 5845, 993, 30, 2676, 21042, 30, 2857, 7937, 30, 5625, 7937, 30, 461, 5625, 5036, 32, 5412, 16709, 13021, 1659, 203, 7546, 902, 966, 461, 13622, 35451, 8528, 883, 1159, 1591, 432, 322, 2412, 16709, 13021, 44, 945, 30, 3568, 30, 556, 562, 32, 319, 12400, 8528, 884, 8702, 1755, 372, 2074, 8999, 32, 1348, 5748, 438, 322, 1244, 16709, 3193, 436, 537, 8528, 30, 461, 438, 322, 4630, 14706, 16709, 3193, 436, 1370, 706, 32, 319, 11540, 8528, 884, 8702, 372, 1169, 4250, 688, 884, 12946, 328, 372, 25697, 7578, 32, 319, 5056, 8528, 884, 8702, 372, 15157, 32, 2614, 2723, 2074, 2857, 372, 1755, 2074, 8999, 30, 6153, 322, 2412, 6655, 44, 2831, 203, 35, 32, 8649, 322, 2074, 19372, 30, 5021, 9923, 848, 6146, 32, 225, 36, 32, 2704, 322, 6146, 9923, 1938, 30, 5021, 32169, 848, 2074, 5359, 848, 4227, 32, 225, 37, 32, 4591, 332, 322, 5412, 16709, 5748, 32, 225, 38, 32, 6608, 12400, 30, 415, 561, 438, 646, 3425, 4324, 32, 225, 39, 32, 11854, 9875, 3404, 32, 5412, 26050, 1659, 203, 7546, 902, 966, 461, 13622, 35451, 438, 312, 8668, 25966, 15332, 10613, 4706, 688, 438, 3304, 372, 1169, 47021, 31878, 4250, 32, 1670, 844, 884, 312, 5575, 902, 966, 461, 13622, 35451, 2074, 30398, 1352, 556, 24543, 30, 844, 883, 31207, 1346, 1256, 461, 2350, 8999, 372, 322, 2074, 32, 25697, 7578, 15307, 1289, 26808, 544, 6560, 844, 883, 31207, 372, 312, 2074, 32, 203, 203, 3092, 225, 35, 203, 5125, 844, 1487, 312, 2074, 328, 5575, 902, 966, 461, 13622, 35451, 30, 1273, 2670, 844, 1663, 7421, 1346, 2276, 30, 5654, 30, 9212, 30, 556, 1604, 706, 623, 322, 2074, 30, 6119, 322, 2074, 4070, 461, 1539, 1346, 4070, 688, 884, 7506, 372, 23809, 1370, 706, 32, 9923, 372, 6119, 2305, 16709, 13021, 30, 4096, 15873, 30, 5845, 993, 30, 2676, 21042, 30, 2857, 7937, 30, 5625, 7937, 30, 461, 5625, 5036, 32, 5412, 16709, 13021, 1659, 203, 7546, 902, 966, 461, 13622, 35451, 8528, 883, 1159, 1591, 432, 322, 2412, 16709, 13021, 44, 945, 30, 3568, 30, 556, 562, 32, 319, 12400, 8528, 884, 8702, 1755, 372, 2074, 8999, 32, 1348, 5748, 438, 322, 1244, 16709, 3193, 436, 537, 8528, 30, 461, 438, 322, 4630, 14706, 16709, 3193, 436, 1370, 706, 32, 319, 11540, 8528, 884, 8702, 372, 1169, 4250, 688, 884, 12946, 328, 372, 25697, 7578, 32, 319, 5056, 8528, 884, 8702, 372, 15157, 32, 2614, 2723, 2074, 2857, 372, 1755, 2074, 8999, 30, 6153, 322, 2412, 6655, 44, 2831, 203, 35, 32, 8649, 322, 2074, 19372, 30, 5021, 9923, 848, 6146, 32, 225, 36, 32, 2704, 322, 6146, 9923, 1938, 30, 5021, 32169, 848, 2074, 5359, 848, 4227, 32, 225, 37, 32, 4591, 332, 322, 5412, 16709, 5748, 32, 225, 38, 32, 6608, 12400, 30, 415, 561, 438, 646, 3425, 4324, 32, 225, 39, 32, 11854, 9875, 3404, 32, 5412, 4096, 4070, 1659, 203, 1083, 1244, 30, 5575, 902, 966, 461, 13622, 35451, 646, 6856, 2074, 8999, 810, 3352, 432, 4096, 2625, 2074, 22076, 32, 8204, 26914, 18214, 2305, 9697, 31, 21152, 706, 688, 1597, 3943, 372, 5575, 902, 966, 461, 13622, 35451, 810, 4250, 32, 2616, 2280, 30, 415, 312, 1256, 14765, 312, 5093, 372, 600, 2427, 30, 5575, 902, 966, 461, 13622, 35451, 18613, 600, 4096, 372, 1169, 40660, 32, 886, 4096, 8600, 2471, 3751, 619, 312, 1933, 432, 322, 5093, 30, 322, 1256, 6560, 21464, 561, 30, 461, 1412, 322, 5093, 1597, 21464, 32, 2614, 6927, 2126, 1169, 4096, 15873, 436, 1370, 2074, 30, 6153, 322, 2412, 6655, 44, 2831, 203, 35, 32, 8649, 322, 2074, 19372, 30, 5021, 9923, 848, 6146, 32, 225, 36, 32, 2704, 322, 1115, 8627, 9923, 1115, 1637, 30, 5021, 32169, 848, 2074, 5359, 848, 4227, 32, 225, 37, 32, 6608, 322, 17616, 4096, 15873, 20569, 32, 225, 38, 32, 11854, 9875, 3404, 32, 5412, 5845, 993, 461, 2676, 12329, 0, 203, 49152, 496, 49153, 8197, 438, 322, 16709, 3193, 432, 5575, 902, 966, 461, 13622, 35451, 8528, 49, 0, 203, 49152, 17594, 49153, 46, 100, 34, 48, 5575, 902, 966, 461, 13622, 35451, 8528, 883, 1159, 1591, 432, 8019, 16709, 13021, 44, 945, 30, 3568, 30, 556, 562, 32, 333, 100, 35, 48, 12400, 8528, 884, 8702, 1755, 372, 2074, 8999, 30, 3568, 8528, 884, 8702, 372, 1169, 12946, 31, 266, 25697, 7578, 4250, 30, 461, 562, 8528, 884, 8702, 372, 15157, 32, 0, 203, 49152, 2946, 49153, 7334, 322, 2401, 47330, 1789, 1991, 10090, 28842, 32, 2616, 2504, 15430, 328, 322, 2401, 47330, 1789, 30, 12411, 322, 2093, 450, 2790, 4321, 6793, 2155, 32, 15545, 688, 1370, 1688, 8600, 1169, 1789, 15430, 15342, 30, 461, 436, 2504, 1789, 15430, 2484, 30, 2355, 322, 8435, 2093, 450, 2790, 4321, 6793, 2155, 32, 886, 1688, 2298, 526, 312, 2361, 5193, 32, 0], prompt_embeds shape: None, lora_request: LoRARequest(lora_name='hallucination_detection', lora_int_id=1, lora_path='/home/freiss/.cache/huggingface/hub/models--ibm-granite--granite-3.3-8b-rag-agent-lib/snapshots/310479c72458e1ebbad00baa010a37b0003f89c8/hallucination_detection_lora', lora_local_path=None, long_lora_max_len=None, base_model_name=None, tensorizer_config_dict=None), prompt_adapter_request: None.\n",
-      "INFO 06-13 11:33:24 [engine.py:316] Added request cmpl-d97864314bac4130aa5d40ed92bb27df-0.\n",
-      "INFO 06-13 11:33:26 [metrics.py:486] Avg prompt throughput: 215.0 tokens/s, Avg generation throughput: 8.3 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 1.0%, CPU KV cache usage: 0.0%.\n",
-      "INFO 06-13 11:33:31 [metrics.py:486] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 11.0 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 1.1%, CPU KV cache usage: 0.0%.\n",
-      "INFO 06-13 11:33:36 [metrics.py:486] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 10.9 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 1.1%, CPU KV cache usage: 0.0%.\n",
-      "INFO:     127.0.0.1:40192 - \"POST /v1/completions HTTP/1.1\" 200 OK\n"
-     ]
-    },
-    {
-     "ename": "ValueError",
-     "evalue": "ERROR: the JSON object must be str, bytes or bytearray, not list (raw output: completion_string='[{\"i\": 0, \"r\": \"This sentence makes a factual claim about the visibility levels of Git Repos and Issue Tracking projects. The document states \\'Git Repos and Issue Tracking projects can have one of the following visibility levels: private, internal, or public.\\' This matches exactly with the claim in the sentence.\", \"f\": \"faithful\"}, {\"i\": 1, \"r\": \"This sentence makes factual claims about the visibility of each level. The document states \\'Private projects are visible only to project members,\\' \\'Internal projects are visible to all users that are logged in to IBM Cloud,\\' and \\'Public projects are visible to anyone.\\' This matches exactly with the claims in the sentence.\", \"f\": \"faithful\"}]' completion_tokens=[] stop_reason='stop')",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/mnt/nvmedisk/freiss/granite/granite-io/src/granite_io/io/hallucinations/hallucinations.py:326\u001b[39m, in \u001b[36mHallucinationsIOProcessor.output_to_result\u001b[39m\u001b[34m(self, output, inputs)\u001b[39m\n\u001b[32m    325\u001b[39m parsed_json = json.loads(raw_result.completion_string)\n\u001b[32m--> \u001b[39m\u001b[32m326\u001b[39m parsed_json = \u001b[43mjson\u001b[49m\u001b[43m.\u001b[49m\u001b[43mloads\u001b[49m\u001b[43m(\u001b[49m\u001b[43mparsed_json\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    327\u001b[39m hallucinations = []\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/mnt/nvmedisk/freiss/granite/env/lib/python3.11/json/__init__.py:339\u001b[39m, in \u001b[36mloads\u001b[39m\u001b[34m(s, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)\u001b[39m\n\u001b[32m    338\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(s, (\u001b[38;5;28mbytes\u001b[39m, \u001b[38;5;28mbytearray\u001b[39m)):\n\u001b[32m--> \u001b[39m\u001b[32m339\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m'\u001b[39m\u001b[33mthe JSON object must be str, bytes or bytearray, \u001b[39m\u001b[33m'\u001b[39m\n\u001b[32m    340\u001b[39m                     \u001b[33mf\u001b[39m\u001b[33m'\u001b[39m\u001b[33mnot \u001b[39m\u001b[38;5;132;01m{\u001b[39;00ms.\u001b[34m__class__\u001b[39m.\u001b[34m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m'\u001b[39m)\n\u001b[32m    341\u001b[39m s = s.decode(detect_encoding(s), \u001b[33m'\u001b[39m\u001b[33msurrogatepass\u001b[39m\u001b[33m'\u001b[39m)\n",
-      "\u001b[31mTypeError\u001b[39m: the JSON object must be str, bytes or bytearray, not list",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[7]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      2\u001b[39m io_proc = HallucinationsIOProcessor(lora_backend)\n\u001b[32m      4\u001b[39m \u001b[38;5;66;03m# Pass our example input thorugh the I/O processor and retrieve the result\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m chat_result = \u001b[38;5;28;01mawait\u001b[39;00m io_proc.acreate_chat_completion(next_chat_input)\n\u001b[32m      7\u001b[39m next_message = chat_result.results[\u001b[32m0\u001b[39m].next_message\n\u001b[32m      8\u001b[39m \u001b[38;5;28mprint\u001b[39m(next_message.model_dump_json(indent=\u001b[32m2\u001b[39m))\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/mnt/nvmedisk/freiss/granite/granite-io/src/granite_io/io/base.py:257\u001b[39m, in \u001b[36mModelDirectInputOutputProcessorWithGenerate.acreate_chat_completion\u001b[39m\u001b[34m(self, inputs)\u001b[39m\n\u001b[32m    255\u001b[39m generate_inputs = \u001b[38;5;28mself\u001b[39m.inputs_to_generate_inputs(inputs)\n\u001b[32m    256\u001b[39m model_output = \u001b[38;5;28;01mawait\u001b[39;00m \u001b[38;5;28mself\u001b[39m._backend.pipeline(generate_inputs)\n\u001b[32m--> \u001b[39m\u001b[32m257\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moutput_to_result\u001b[49m\u001b[43m(\u001b[49m\u001b[43moutput\u001b[49m\u001b[43m=\u001b[49m\u001b[43mmodel_output\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43minputs\u001b[49m\u001b[43m=\u001b[49m\u001b[43minputs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/mnt/nvmedisk/freiss/granite/granite-io/src/granite_io/io/hallucinations/hallucinations.py:363\u001b[39m, in \u001b[36mHallucinationsIOProcessor.output_to_result\u001b[39m\u001b[34m(self, output, inputs)\u001b[39m\n\u001b[32m    360\u001b[39m     hallucinations = []\n\u001b[32m    362\u001b[39m     \u001b[38;5;66;03m# TEMPORARY: Pass through errors for now\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m363\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(content) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01me\u001b[39;00m\n\u001b[32m    365\u001b[39m \u001b[38;5;66;03m# print(f\"Adding {raw_result.completion_string} as raw result\")\u001b[39;00m\n\u001b[32m    366\u001b[39m next_message = inputs.messages[-\u001b[32m1\u001b[39m].model_copy(\n\u001b[32m    367\u001b[39m     update={\n\u001b[32m    368\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mcontent\u001b[39m\u001b[33m\"\u001b[39m: content,\n\u001b[32m   (...)\u001b[39m\u001b[32m    372\u001b[39m     }\n\u001b[32m    373\u001b[39m )\n",
-      "\u001b[31mValueError\u001b[39m: ERROR: the JSON object must be str, bytes or bytearray, not list (raw output: completion_string='[{\"i\": 0, \"r\": \"This sentence makes a factual claim about the visibility levels of Git Repos and Issue Tracking projects. The document states \\'Git Repos and Issue Tracking projects can have one of the following visibility levels: private, internal, or public.\\' This matches exactly with the claim in the sentence.\", \"f\": \"faithful\"}, {\"i\": 1, \"r\": \"This sentence makes factual claims about the visibility of each level. The document states \\'Private projects are visible only to project members,\\' \\'Internal projects are visible to all users that are logged in to IBM Cloud,\\' and \\'Public projects are visible to anyone.\\' This matches exactly with the claims in the sentence.\", \"f\": \"faithful\"}]' completion_tokens=[] stop_reason='stop')"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO 06-13 11:33:48 [metrics.py:486] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 1.8 tokens/s, Running: 0 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.0%, CPU KV cache usage: 0.0%.\n",
-      "INFO 06-13 11:33:58 [metrics.py:486] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.0%, CPU KV cache usage: 0.0%.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Instantiate the I/O processor for the hallucinations LoRA adapter\n",
     "io_proc = HallucinationsIOProcessor(lora_backend)\n",

--- a/src/granite_io/io/rag_agent_lib/__init__.py
+++ b/src/granite_io/io/rag_agent_lib/__init__.py
@@ -3,11 +3,32 @@
 
 # Local
 from .util import RagAgentLibModelInfo, obtain_lora
+from granite_io.io.answerability.answerability import (
+    AnswerabilityCompositeIOProcessor,
+    AnswerabilityIOProcessor,
+)
+from granite_io.io.certainty.certainty import (
+    AssistantMessageWithScore,
+    CertaintyCompositeIOProcessor,
+    CertaintyIOProcessor,
+)
 
 # This file is the root package for IO processors for the Granite 3.3 RAG Agent Library
 # models.
 # See https://huggingface.co/ibm-granite/granite-3.3-8b-rag-agent-lib
 
+# TODO: Citations
+# TODO: Hallucinations
+# TODO: Query rewrite
+
 
 # Expose public symbols at `granite_io.io.rag_agent_lib` to save users from typing
-__all__ = ["RagAgentLibModelInfo", "obtain_lora"]
+__all__ = [
+    "AssistantMessageWithScore",
+    "AnswerabilityCompositeIOProcessor",
+    "AnswerabilityIOProcessor",
+    "CertaintyCompositeIOProcessor",
+    "CertaintyIOProcessor",
+    "RagAgentLibModelInfo",
+    "obtain_lora",
+]


### PR DESCRIPTION
Update to the changes in #197: Remove output that was accidentally left in the Hallucination notebook. Also pulling in some preliminary changes to `src/granite_io/io/rag_agent_lib/__init__.py` to avoid merge conflicts later.