### PR TITLE
Added first set of tweaks to close #153 (attempt 2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,11 +63,46 @@ You can run your dev environment using [tox](https://tox.wiki), which is an envi
 
 If you want to manage your own virtual environment instead of using `tox`, you can install granite io processing and all dependencies. Check out [README](./README.md) for more details.
 
+> [!IMPORTANT]
+> **First-time Setup**: Some tests require machine learning models from HuggingFace that will be automatically downloaded on first run. Ensure you have internet connectivity and ~1GB of free disk space. See the [HuggingFace Model Dependencies](#huggingface-model-dependencies) section below for details.
+
 Before pushing changes to GitHub, you need to run the tests, coding style and spelling check as shown below. They can be run individually as shown in each sub-section or can be run with the one command:
 
 ```shell
 tox
 ```
+
+### HuggingFace Model Dependencies
+
+Some tests in this project require machine learning models from [HuggingFace](https://huggingface.co/) that are automatically downloaded on first use. This is particularly relevant for tests related to retrieval and embedding functionality.
+
+#### Important Notes for Developers
+
+- **First Test Run**: When running retrieval tests for the first time, models will be automatically downloaded from HuggingFace
+- **Internet Required**: Initial test runs require internet connectivity to download models
+- **Disk Space**: The embedding model (`sentence-transformers/multi-qa-mpnet-base-dot-v1`) is approximately 438MB
+- **Download Time**: First test run may take significantly longer due to model download
+- **Caching**: Models are cached in `~/.cache/huggingface/hub/` and reused for subsequent runs
+
+#### Affected Tests
+
+The following test files require HuggingFace models:
+- `tests/io/test_retrieval.py` - Requires `sentence-transformers/multi-qa-mpnet-base-dot-v1`
+- `tests/io/test_rerank.py` - Requires `sentence-transformers/multi-qa-mpnet-base-dot-v1`
+
+#### Manual Model Download (Optional)
+
+If you prefer to download models manually before running tests, you can use:
+```shell
+pip install -U "huggingface_hub[cli]"
+huggingface-cli download sentence-transformers/multi-qa-mpnet-base-dot-v1
+```
+
+#### Troubleshooting
+
+- **Network Issues**: If download fails, ensure you have stable internet connectivity
+- **Cache Issues**: If experiencing model loading problems, try clearing the cache: `rm -rf ~/.cache/huggingface/`
+- **Disk Space**: Ensure you have at least 1GB of free disk space for model storage
 
 ### Unit tests
 
@@ -84,7 +119,8 @@ By default, all tests found within the tests directory are run. However, specifi
 ```shell
 tox -e unit -- tests/io/test_granite_3_2.py::test_read_inputs
 ```
-#### OpenAI env
+
+#### OpenAI Environment Variables
 
 The OpenAI tests will by default find a typical local ollama installation, but you can use environment variables
 to refer to another server by specifying the URL and API_KEY (if required).  The environment variables are as follows:
@@ -94,6 +130,8 @@ to refer to another server by specifying the URL and API_KEY (if required).  The
 | OPENAI_BASE_URL | http://localhost:11434/v1 | Base URL for OpenAI endpoints  |
 | OPENAI_API_KEY  | ollama                    | API Key (depends on provider)  |
 | MODEL_NAME      | granite3.2:2b             | Model name on backend provider |
+
+> **Note**: These environment variables are separate from the HuggingFace model requirements mentioned above. OpenAI tests connect to external services, while HuggingFace models are downloaded and cached locally.
 
 ### Coding style
 

--- a/tests/io/test_rerank.py
+++ b/tests/io/test_rerank.py
@@ -2,6 +2,10 @@
 
 """
 Test cases for the llm rerank intrinsic.
+
+Note: These tests require the HuggingFace model 'sentence-transformers/multi-qa-mpnet-base-dot-v1'
+which will be automatically downloaded on first run (~438MB). Ensure you have internet
+connectivity and sufficient disk space. See CONTRIBUTING.md for more details.
 """
 
 # Standard

--- a/tests/io/test_retrieval.py
+++ b/tests/io/test_retrieval.py
@@ -2,6 +2,10 @@
 
 """
 Test cases for the retrieval intrinsic.
+
+Note: These tests require the HuggingFace model 'sentence-transformers/multi-qa-mpnet-base-dot-v1'
+which will be automatically downloaded on first run (~438MB). Ensure you have internet
+connectivity and sufficient disk space. See CONTRIBUTING.md for more details.
 """
 
 # Standard


### PR DESCRIPTION
Hey Y'all, apologies if you saw the first attempt - not sure what was going on with GitHub GUI, but I think it's fixed now.

---

This PR addresses concerns/bugs described in https://github.com/ibm-granite/granite-io/issues/153:

- Test File Updates:
  - Updated docstrings in test_retrieval.py and test_rerank.py to:
      - Alert developers to the model download requirement
      - Reduce future confusion during local test runs
- CONTRIBUTING.md:
  - Added a new "HuggingFace Model Dependencies" section with:
  - Explanation of automatic model download behavior
  - Notes on internet access, disk space (~438MB), and download time
  - List of affected test files (`test_retrieval.py`, `test_rerank.py`)
  - Optional manual download instructions via huggingface-cli
  - Troubleshooting tips for common setup issues
  - Added a callout at the top of the Development section highlighting model download requirements for first-time setup
  - Clarified distinction between OpenAI dependencies and HuggingFace model requirements in the OpenAI environment section

Thank you for your time - and as always, please feel free to make changes as needed! :-)