### PR TITLE
Fix for issue #246 incomplete augment of loop objects on error cases

### DIFF
--- a/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
+++ b/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
@@ -177,6 +177,11 @@ def _add_hallucination_response_spans(
     augmented_hallucination_info = copy.deepcopy(hallucination_info)
 
     for hallucination in augmented_hallucination_info:
+        # Init values in event of error in processing
+        hallucination["response_text"] = ""
+        hallucination["response_begin"] = 0
+        hallucination["response_end"] = 0
+
         hallucination_response_text_without_citations = (
             _remove_citations_from_response_text(hallucination["response_text"])
         )
@@ -418,6 +423,11 @@ def _add_citation_response_spans(
     # For each citation bring the response sentence to which it refers and its
     # begin/end spans
     for i, citation in enumerate(augmented_citation_info):
+        # Init values in event of error in processing
+        citation["response_text"] = ""
+        citation["response_begin"] = 0
+        citation["response_end"] = 0
+
         response_text = response_sents_by_citation_id.get(str(i), "")
         index = response_text_without_citations.find(response_text)
         if index < 0:

--- a/src/granite_io/io/hallucinations/hallucinations.py
+++ b/src/granite_io/io/hallucinations/hallucinations.py
@@ -90,10 +90,10 @@ def mark_sentence_boundaries(
 
 class HallucinationsIOProcessor(ModelDirectInputOutputProcessorWithGenerate):
     """
-    I/O processor for the Granite hallucinations intrinsic, also known as the [LoRA 
-    Adapter for Hallucination Detection](https://huggingface.co/ibm-granite/granite-3.3-8b-rag-agent-lib/blob/main/hallucination_detection_lora/README.md). 
-    
-    Takes as input a chat completion and returns a version of the completion with 
+    I/O processor for the Granite hallucinations intrinsic, also known as the [LoRA
+    Adapter for Hallucination Detection](https://huggingface.co/ibm-granite/granite-3.3-8b-rag-agent-lib/blob/main/hallucination_detection_lora/README.md).
+
+    Takes as input a chat completion and returns a version of the completion with
     hallucinations detected on the last assistant turn.
 
     Example input to the IO processor's :func`acreate_chat_completion()` call:
@@ -380,7 +380,7 @@ are visible to anyone.",
                     "content": content,
                     "hallucinations": hallucinations,
                     # TEMPORARY -- should be original message's raw result
-                    "raw": raw_result.completion_string,
+                    "_raw": raw_result.completion_string,
                 }
             )
 


### PR DESCRIPTION
Fixes #246. Add init values for citation and hallucination objects in augment functions so that on errors, the objects have the required fields.

Includes commits from #242 as I'm dependent on both branches for dev for benchmarking composite intrinsics.

Update: Also contains fix for #248 