### PR TITLE
Fix regression in hallucination parsing

### DIFF
--- a/notebooks/.gitignore
+++ b/notebooks/.gitignore
@@ -1,0 +1,1 @@
+debug_*.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ nltk = [
     "nltk~=3.9.1",
 ]
 openai = [
-    "openai >= 1.68.2, < 2.0",
+    # As of August 18, 2025, OpenAI v1.100 breaks all versions of LiteLLM
+    "openai >= 1.68.2, < 1.100",
 ]
 litellm = [
     "litellm >= 1.63.14, < 2.0",

--- a/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
+++ b/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
@@ -177,11 +177,6 @@ def _add_hallucination_response_spans(
     augmented_hallucination_info = copy.deepcopy(hallucination_info)
 
     for hallucination in augmented_hallucination_info:
-        # Init values in event of error in processing
-        hallucination["response_text"] = ""
-        hallucination["response_begin"] = 0
-        hallucination["response_end"] = 0
-
         hallucination_response_text_without_citations = (
             _remove_citations_from_response_text(hallucination["response_text"])
         )
@@ -194,6 +189,9 @@ def _add_hallucination_response_spans(
                 "Error in adding the response spans to hallucination: "
                 "Hallucination text not found in response"
             )
+            # Install placeholder values to avoid breaking downstream code.
+            hallucination["response_begin"] = 0
+            hallucination["response_end"] = 0
             continue
 
         if len(matches) > 1:


### PR DESCRIPTION
#247 introduced a regression in hallucination parsing for Granite 3.3. I'm not sure why CI didn't catch this regression. This PR introduces a fix.

I've also added a workaround for https://github.com/BerriAI/litellm/issues/13711 to unblock CI of this PR.

I've also tweaked the .gitignore file for the notebooks directory to prevent temporary notebooks whose names start with "debug" from being checked into source control.