### PR TITLE
fix: escaping of regex digit class

### DIFF
--- a/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
+++ b/src/granite_io/io/granite_3_3/output_processors/granite_3_3_output_parser.py
@@ -383,7 +383,7 @@ def _add_citation_response_spans(
     citation_idx = 0
     for sent_idx, sent in enumerate(response_sentences):
         # pylint: disable=anomalous-backslash-in-string
-        pattern = f'{re.escape(_GRANITE_3_3_CITE_START)}{{"document_id": "(\d+)"}}{re.escape(_GRANITE_3_3_CITE_END)}'
+        pattern = f'{re.escape(_GRANITE_3_3_CITE_START)}{{"document_id": "(\\d+)"}}{re.escape(_GRANITE_3_3_CITE_END)}'
         matches_iter = re.finditer(pattern, sent)
         for match in matches_iter:
             citation_id = str(citation_idx)


### PR DESCRIPTION
The current implementation fails with:
> \<stdin\>:1: SyntaxWarning: invalid escape sequence '\d'

When escaping a regex, two backslashes are required, as per this fix.